### PR TITLE
feat: improve tracker UX, reminders, and snapshot timing

### DIFF
--- a/src/data/emoji-keywords.js
+++ b/src/data/emoji-keywords.js
@@ -93,10 +93,12 @@ export default {
 
   // Nature & Plants
   '🌹': ['rose', 'flower', 'red', 'love', 'romantic'],
+  '🌸': ['cherry', 'blossom', 'flower', 'pink', 'spring', 'japan', 'sakura'],
   '🌻': ['sunflower', 'yellow', 'flower', 'sun', 'bright'],
   '🌱': ['seedling', 'plant', 'grow', 'green', 'sprout'],
   '🌲': ['tree', 'evergreen', 'pine', 'forest', 'christmas'],
   '🌵': ['cactus', 'desert', 'spikes', 'green', 'prickly'],
+  '🍀': ['four', 'leaf', 'clover', 'lucky', 'green', 'ireland', 'fortune'],
   '🍁': ['leaf', 'autumn', 'fall', 'maple', 'orange'],
   '🍄': ['mushroom', 'fungi', 'red', 'white', 'spots'],
 
@@ -150,6 +152,7 @@ export default {
   '🍪': ['cookie', 'sweet', 'dessert', 'chocolate', 'chip'],
   '🍰': ['cake', 'birthday', 'dessert', 'sweet', 'slice'],
   '🍫': ['chocolate', 'sweet', 'brown', 'candy', 'bar'],
+  '🍬': ['candy', 'sweet', 'wrapped', 'sugar', 'treat'],
   '🍭': ['lollipop', 'candy', 'sweet', 'stick', 'colorful'],
   '🍯': ['honey', 'sweet', 'bee', 'golden', 'sticky'],
   '🍺': ['beer', 'alcohol', 'drink', 'foam', 'mug'],
@@ -218,6 +221,7 @@ export default {
   '🔥': ['fire', 'hot', 'flame', 'burn', 'heat'],
   '💧': ['water', 'drop', 'blue', 'wet', 'liquid'],
   '🌊': ['wave', 'ocean', 'water', 'sea', 'surf'],
+  '❄️': ['snowflake', 'snow'],
 
   // Clothing & Accessories
   '👓': ['glasses', 'eyeglasses', 'vision', 'nerd', 'smart'],

--- a/src/schedules/index.js
+++ b/src/schedules/index.js
@@ -5,6 +5,7 @@ import initializePoint from '../service/schedules/initialize-point.js';
 import checkAndSendReminders from '../service/schedules/check-and-send-reminders.js';
 import trackerDailyMaintenance from '../service/schedules/tracker-daily-maintenance.js';
 import trackerWeeklySnapshots from '../service/schedules/tracker-weekly-snapshots.js';
+import trackerDailyReminders from '../service/schedules/tracker-daily-reminders.js';
 
 export default function schedules() {
   // every 10 seconds
@@ -22,6 +23,7 @@ export default function schedules() {
   schedule.scheduleJob('0 0 * * *', () => {
     sendANewMatchMatchMessage();
     trackerDailyMaintenance();
+    trackerDailyReminders();
   });
 
   // every Sunday at 01:00 (weekly snapshots)

--- a/src/service/interaction/is-chat-input-command/join-tracker.js
+++ b/src/service/interaction/is-chat-input-command/join-tracker.js
@@ -8,7 +8,7 @@ import channelLog from '../../utils/channel-log.js';
 import EMOJI_KEYWORDS from '../../../data/emoji-keywords.js';
 
 export default async function joinTracker(interaction) {
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ ephemeral: false });
 
   try {
     // Validate this is a thread

--- a/src/service/messageCreate/tracker-checkin.js
+++ b/src/service/messageCreate/tracker-checkin.js
@@ -29,52 +29,102 @@ export default async function trackerCheckin(message) {
     // Check if user is a participant
     const participant = await TrackerParticipant.findOne({ trackerId: threadId, userId });
     if (!participant) {
+      await message.react('❌').catch(() => {});
       await message.reply(
         '❌ You are not participating in this tracker. Use `/tracker-join` to join.',
       );
       return;
     }
 
-    // Parse command: !checkin done|break [YYYY-MM-DD]
+    // Parse command: !checkin done|break [yesterday|Xdays|Xd|--date YYYY-MM-DD] <activity message>
     const content = message.content.trim();
     const args = content.split(/\s+/);
 
     if (args.length < 2) {
-      await message.reply('❌ Usage: `!checkin done|break [YYYY-MM-DD]`');
+      await message.react('❌').catch(() => {});
+      await message.reply(
+        '❌ Usage: `!checkin done|break [yesterday|2days|--date YYYY-MM-DD] <activity message>`',
+      );
       return;
     }
 
     const type = args[1].toLowerCase();
     if (!['done', 'break'].includes(type)) {
+      await message.react('❌').catch(() => {});
       await message.reply('❌ Check-in type must be `done` or `break`');
       return;
     }
 
-    // Parse optional date
+    // Parse optional date (relative or --date flag) and activity message
     let targetDate = new Date();
+    let activityMessage = '';
+    let dateArgIndex = -1;
+    let dateArgCount = 0; // How many args to skip for date
 
-    if (args.length === 3) {
-      // Third argument should be a date in YYYY-MM-DD format
-      const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    // Look for relative dates or --date flag
+    if (args.length > 2) {
+      const dateArg = args[2].toLowerCase();
 
-      if (!dateRegex.test(args[2])) {
-        await message.reply('❌ Invalid date format. Use YYYY-MM-DD');
-        return;
-      }
+      // Check for relative dates: yesterday, 2days, 2d, 3days, 3d, etc.
+      if (dateArg === 'yesterday') {
+        targetDate = new Date();
+        targetDate.setDate(targetDate.getDate() - 1);
+        dateArgIndex = 2;
+        dateArgCount = 1;
+      } else if (/^\d+days?$/.test(dateArg) || /^\d+d$/.test(dateArg)) {
+        // Match: 2days, 2day, 2d, 3days, 3d, etc.
+        const daysAgo = parseInt(dateArg.match(/^\d+/)[0], 10);
+        targetDate = new Date();
+        targetDate.setDate(targetDate.getDate() - daysAgo);
+        dateArgIndex = 2;
+        dateArgCount = 1;
+      } else if (dateArg === '--date' && args.length > 3) {
+        // --date flag with explicit date
+        const dateStr = args[3];
+        const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
-      try {
-        targetDate = new Date(args[2] + 'T00:00:00.000Z');
-        if (Number.isNaN(targetDate.getTime())) {
-          throw new Error('Invalid date');
+        if (!dateRegex.test(dateStr)) {
+          await message.react('❌').catch(() => {});
+          await message.reply('❌ Invalid date format. Use YYYY-MM-DD after --date flag');
+          return;
         }
-      } catch (error) {
-        await message.reply('❌ Invalid date format. Use YYYY-MM-DD');
+
+        try {
+          targetDate = new Date(dateStr + 'T00:00:00.000Z');
+          if (Number.isNaN(targetDate.getTime())) {
+            throw new Error('Invalid date');
+          }
+        } catch (error) {
+          await message.react('❌').catch(() => {});
+          await message.reply('❌ Invalid date format. Use YYYY-MM-DD after --date flag');
+          return;
+        }
+        dateArgIndex = 2;
+        dateArgCount = 2; // Skip both --date and the date value
+      }
+    }
+
+    // Extract activity message (everything after type, excluding date args)
+    const messageStartIndex = 2;
+    const messageParts = [];
+    for (let i = messageStartIndex; i < args.length; i++) {
+      if (dateArgIndex !== -1 && i >= dateArgIndex && i < dateArgIndex + dateArgCount) {
+        continue; // Skip date arguments
+      }
+      messageParts.push(args[i]);
+    }
+    activityMessage = messageParts.join(' ').trim();
+
+    // Validate activity message for 'done' check-ins (10 chars excluding spaces)
+    if (type === 'done') {
+      const activityWithoutSpaces = activityMessage.replace(/\s/g, '');
+      if (activityWithoutSpaces.length < 10) {
+        await message.react('❌').catch(() => {});
+        await message.reply(
+          '❌ Please include a meaningful description of what you did (at least 10 characters). Usage: `!checkin done [yesterday|2days|--date YYYY-MM-DD] <activity message>`',
+        );
         return;
       }
-    } else if (args.length > 3) {
-      // Too many arguments
-      await message.reply('❌ Usage: `!checkin done|break [YYYY-MM-DD]`');
-      return;
     }
 
     // Validate date constraints
@@ -84,12 +134,14 @@ export default async function trackerCheckin(message) {
 
     // No future dates
     if (checkDate > today) {
+      await message.react('❌').catch(() => {});
       await message.reply('❌ Cannot check in for future dates');
       return;
     }
 
     // Must be within tracker period
     if (!isDateInTrackerPeriod(checkDate, tracker.startDate, tracker.endDate)) {
+      await message.react('❌').catch(() => {});
       await message.reply('❌ Date is outside the tracker period');
       return;
     }
@@ -97,6 +149,7 @@ export default async function trackerCheckin(message) {
     // Must be after user joined
     const joinDate = getStartOfDay(participant.joinedAt);
     if (checkDate < joinDate) {
+      await message.react('❌').catch(() => {});
       await message.reply('❌ Cannot check in for dates before you joined the tracker');
       return;
     }
@@ -106,6 +159,7 @@ export default async function trackerCheckin(message) {
       (today.getTime() - checkDate.getTime()) / (1000 * 60 * 60 * 24),
     );
     if (daysSinceDate > tracker.gracePeriodDays) {
+      await message.react('❌').catch(() => {});
       await message.reply(
         `❌ Cannot backfill check-ins older than ${tracker.gracePeriodDays} days (grace period)`,
       );
@@ -115,6 +169,7 @@ export default async function trackerCheckin(message) {
     // Weekly tracker specific validation
     if (tracker.frequency === 'weekly') {
       if (type === 'break') {
+        await message.react('❌').catch(() => {});
         await message.reply('❌ Break check-ins are not supported for weekly trackers');
         return;
       }
@@ -140,6 +195,7 @@ export default async function trackerCheckin(message) {
       });
 
       if (existingBreaks >= tracker.maxBreaksPerWeek) {
+        await message.react('❌').catch(() => {});
         await message.reply(
           `❌ Break limit reached for this week (${tracker.maxBreaksPerWeek} max). Use \`!checkin done\` if you completed the task. If you do nothing, this day will remain ⬜ and will become ❌ after the grace period expires.`,
         );
@@ -198,6 +254,7 @@ export default async function trackerCheckin(message) {
     await updateLiveTracker(threadId, message.channel);
   } catch (error) {
     console.error('Error processing tracker check-in:', error);
+    await message.react('❌').catch(() => {});
     await message.reply('❌ An error occurred while processing your check-in. Please try again.');
   }
 }

--- a/src/service/schedules/tracker-daily-reminders.js
+++ b/src/service/schedules/tracker-daily-reminders.js
@@ -1,0 +1,71 @@
+import Tracker from '../../models/tracker.js';
+import client from '../../client/index.js';
+import channelLog from '../utils/channel-log.js';
+
+/**
+ * Daily reminders for trackers:
+ * - Daily trackers: Post reminder every day
+ * - Weekly trackers: Post reminder at the start of each week (every 7 days)
+ */
+export default async function trackerDailyReminders() {
+  try {
+    const activeTrackers = await Tracker.find({ isActive: true });
+
+    for (const tracker of activeTrackers) {
+      await sendTrackerReminder(tracker);
+    }
+
+    channelLog(`Tracker daily reminders processed for ${activeTrackers.length} trackers`);
+  } catch (error) {
+    console.error('Error in tracker daily reminders:', error);
+  }
+}
+
+async function sendTrackerReminder(tracker) {
+  try {
+    const channel = await client.channels.fetch(tracker.threadId);
+    if (!channel) {
+      return;
+    }
+
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+
+    const startDate = new Date(tracker.startDate);
+    startDate.setHours(0, 0, 0, 0);
+
+    const endDate = new Date(tracker.endDate);
+    endDate.setHours(23, 59, 59, 999);
+
+    // Check if we're within the tracker period
+    if (now < startDate || now > endDate) {
+      return; // Outside tracker period, don't send reminder
+    }
+
+    // Calculate day number from tracker start
+    const daysSinceStart = Math.floor(
+      (now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    const dayNumber = daysSinceStart + 1; // Day 1, Day 2, etc.
+
+    if (tracker.frequency === 'daily') {
+      // Daily tracker: Send reminder every day
+      await channel.send(
+        `📅 Day ${dayNumber} - Don't forget to check in today! Use \`!checkin done <activity>\``,
+      );
+      channelLog(`Daily reminder sent for tracker: ${tracker.threadId} | Day ${dayNumber}`);
+    } else if (tracker.frequency === 'weekly') {
+      // Weekly tracker: Send reminder at the start of each week (every 7 days)
+      // Week starts on day 1, 8, 15, 22, etc.
+      if (dayNumber === 1 || (dayNumber - 1) % 7 === 0) {
+        const weekNumber = Math.floor((dayNumber - 1) / 7) + 1;
+        await channel.send(
+          `📅 Week ${weekNumber} - Don't forget to check in this week! Use \`!checkin done <activity>\``,
+        );
+        channelLog(`Weekly reminder sent for tracker: ${tracker.threadId} | Week ${weekNumber}`);
+      }
+    }
+  } catch (error) {
+    console.error(`Error sending reminder for tracker ${tracker.threadId}:`, error);
+  }
+}

--- a/src/service/schedules/tracker-weekly-snapshots.js
+++ b/src/service/schedules/tracker-weekly-snapshots.js
@@ -1,4 +1,6 @@
 import Tracker from '../../models/tracker.js';
+import TrackerCheckin from '../../models/tracker-checkin.js';
+import TrackerParticipant from '../../models/tracker-participant.js';
 import client from '../../client/index.js';
 import { generateLiveTrackerEmbed } from '../utils/tracker-renderer.js';
 import channelLog from '../utils/channel-log.js';
@@ -8,6 +10,7 @@ import channelLog from '../utils/channel-log.js';
  * - Post immutable weekly snapshot messages
  * - Only for daily trackers
  * - Snapshots are never edited
+ * - Captures the last 14 completed days (ending yesterday)
  */
 export default async function trackerWeeklySnapshots() {
   try {
@@ -34,15 +37,16 @@ async function createWeeklySnapshot(tracker) {
       return;
     }
 
-    // Generate snapshot embed (same as live tracker but immutable)
-    const embed = await generateLiveTrackerEmbed(tracker.threadId);
+    // Generate snapshot embed for the last 14 completed days (ending yesterday)
+    const embed = await generateSnapshotEmbed(tracker.threadId);
     if (!embed) {
       return;
     }
 
-    // Modify embed for snapshot
-    const now = new Date();
-    const weekEnding = now.toLocaleDateString('en-US', {
+    // Calculate yesterday's date for the snapshot label
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const weekEnding = yesterday.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -59,5 +63,130 @@ async function createWeeklySnapshot(tracker) {
     channelLog(`Weekly snapshot created for tracker: ${tracker.threadId} | ${tracker.displayName}`);
   } catch (error) {
     console.error(`Error creating weekly snapshot for tracker ${tracker.threadId}:`, error);
+  }
+}
+
+/**
+ * Generate snapshot embed showing the last 14 completed days
+ */
+async function generateSnapshotEmbed(trackerId) {
+  try {
+    const tracker = await Tracker.findOne({ threadId: trackerId });
+    if (!tracker || tracker.frequency !== 'daily') {
+      return null;
+    }
+
+    // Get all participants sorted by join date
+    const participants = await TrackerParticipant.find({ trackerId: tracker.threadId }).sort({
+      joinedAt: 1,
+    });
+
+    if (participants.length === 0) {
+      return null;
+    }
+
+    // Calculate 14-day window ending yesterday
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(0, 0, 0, 0);
+
+    const windowEnd = yesterday;
+    const windowStart = new Date(windowEnd);
+    windowStart.setDate(windowStart.getDate() - 13);
+
+    // Constrain to tracker period
+    const trackerStart = new Date(tracker.startDate);
+    trackerStart.setHours(0, 0, 0, 0);
+    const trackerEnd = new Date(tracker.endDate);
+    trackerEnd.setHours(0, 0, 0, 0);
+
+    const effectiveWindowStart = windowStart < trackerStart ? trackerStart : windowStart;
+    const effectiveWindowEnd = windowEnd < trackerEnd ? windowEnd : trackerEnd;
+
+    // Generate dates within the window
+    const dates = [];
+    const currentDate = new Date(effectiveWindowStart);
+    while (currentDate <= effectiveWindowEnd) {
+      dates.push(new Date(currentDate));
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    // Get all check-ins for this period
+    const checkins = await TrackerCheckin.find({
+      trackerId: tracker.threadId,
+      date: { $gte: effectiveWindowStart, $lte: effectiveWindowEnd },
+    });
+
+    // Create lookup map
+    const checkinMap = new Map();
+    checkins.forEach((checkin) => {
+      const dateKey = checkin.date.toISOString().split('T')[0];
+      const userKey = `${checkin.userId}-${dateKey}`;
+      checkinMap.set(userKey, checkin);
+    });
+
+    // Build the tracker grid
+    let trackerText = '';
+
+    // Header row with participant emojis
+    participants.forEach((participant) => {
+      trackerText += `${participant.emoji} `;
+    });
+    trackerText += '\n';
+
+    // Date rows
+    for (const date of dates) {
+      const dateKey = date.toISOString().split('T')[0];
+
+      // Check-in cells for each participant on this date
+      for (const participant of participants) {
+        const userKey = `${participant.userId}-${dateKey}`;
+        const checkin = checkinMap.get(userKey);
+
+        let cellEmoji = '⬜'; // Default to missing
+
+        if (checkin) {
+          cellEmoji = checkin.type === 'done' ? '✅' : '🟨';
+        } else {
+          const joinDate = new Date(participant.joinedAt);
+          joinDate.setHours(0, 0, 0, 0);
+
+          if (date < joinDate) {
+            cellEmoji = '🔘'; // Before join
+          } else {
+            // Check if grace period has expired
+            const daysSinceDate = Math.floor(
+              (yesterday.getTime() - date.getTime()) / (1000 * 60 * 60 * 24),
+            );
+
+            if (daysSinceDate > tracker.gracePeriodDays) {
+              cellEmoji = '❌'; // Final miss
+            } else {
+              cellEmoji = '⬜'; // Still missing
+            }
+          }
+        }
+
+        trackerText += `${cellEmoji} `;
+      }
+
+      // Date label
+      const day = date.getDate().toString().padStart(2, '0');
+      const month = date.toLocaleDateString('en-US', { month: 'short' });
+      trackerText += `${month} ${day}\n`;
+    }
+
+    return {
+      color: 0x5865f2,
+      title: `📸 ${tracker.displayName} - Weekly Snapshot`,
+      description: `Please keep in mind that this bot is set to GMT/UTC so each day starts at <t:946684800:t> your time\n\n\`\`\`\n${trackerText}\`\`\``,
+      footer: {
+        text: '✅ Done • 🟨 Break • ⬜ Missing • ❌ Final Miss • 🔘 Before Join',
+      },
+      timestamp: new Date().toISOString(),
+    };
+  } catch (error) {
+    console.error('Error generating snapshot embed:', error);
+    return null;
   }
 }

--- a/src/service/utils/tracker-renderer.js
+++ b/src/service/utils/tracker-renderer.js
@@ -9,6 +9,34 @@ import {
 } from './tracker-utils.js';
 
 /**
+ * Generate participants embed for a tracker
+ */
+async function generateParticipantsEmbed(tracker) {
+  const participants = await TrackerParticipant.find({ trackerId: tracker.threadId }).sort({
+    joinedAt: 1,
+  });
+
+  if (participants.length === 0) {
+    return {
+      color: 0x5865f2,
+      title: '👥 Participants',
+      description: 'No participants yet.',
+    };
+  }
+
+  let participantsList = '';
+  for (const participant of participants) {
+    participantsList += `${participant.emoji} <@${participant.userId}>\n`;
+  }
+
+  return {
+    color: 0x5865f2,
+    title: '👥 Participants',
+    description: participantsList,
+  };
+}
+
+/**
  * Generate the live tracker embed for weekly trackers
  * Shows weeks with completion status instead of daily check-ins
  */
@@ -265,6 +293,7 @@ export async function updateLiveTracker(trackerId, channel) {
     }
 
     const embed = await generateLiveTrackerEmbed(trackerId);
+    const participantsEmbed = await generateParticipantsEmbed(tracker);
     if (!embed) {
       return;
     }
@@ -273,7 +302,7 @@ export async function updateLiveTracker(trackerId, channel) {
       // Try to edit existing message
       try {
         const existingMessage = await channel.messages.fetch(tracker.liveTrackerMessageId);
-        await existingMessage.edit({ embeds: [embed] });
+        await existingMessage.edit({ embeds: [embed, participantsEmbed] });
         return;
       } catch (error) {
         // Message not found, create new one
@@ -281,7 +310,7 @@ export async function updateLiveTracker(trackerId, channel) {
     }
 
     // Create new live tracker message
-    const message = await channel.send({ embeds: [embed] });
+    const message = await channel.send({ embeds: [embed, participantsEmbed] });
     await message.pin();
 
     // Update tracker with new message ID


### PR DESCRIPTION
- Restore --date flag and support relative dates (yesterday, 2days, etc.)
- Require activity message for check-ins (min 10 chars)
- Add ❌ reaction on invalid check-ins
- Add participants embed to tracker message
- Make join confirmation embeds public
- Add daily and weekly challenge reminders
- Fix weekly snapshot to end on last completed day

Closes #23 