### PR TITLE
feat: 41 feature add live and recurring event support

### DIFF
--- a/src/commands/event/calendar.js
+++ b/src/commands/event/calendar.js
@@ -1,0 +1,12 @@
+import { SlashCommandBuilder } from 'discord.js';
+import eventCalendar from '../../service/interaction/is-chat-input-command/event-calendar.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('calendar')
+    .setDescription('Show upcoming and active events'),
+
+  async execute(interaction) {
+    await eventCalendar(interaction);
+  },
+};

--- a/src/commands/event/event.js
+++ b/src/commands/event/event.js
@@ -23,7 +23,6 @@ const EVENT_TYPES = [
   { name: 'Listening', value: 'Listening' },
   { name: 'Speaking', value: 'Speaking' },
   { name: 'Writing', value: 'Writing' },
-  { name: 'Live Event', value: 'Live Event' },
   { name: 'Mixed', value: 'Mixed' },
   { name: 'Other', value: 'Other' },
 ];
@@ -87,7 +86,7 @@ const data = new SlashCommandBuilder()
       .addIntegerOption((o) =>
         o
           .setName('max_points')
-          .setDescription('Maximum points a participant can earn (required if points set)')
+          .setDescription('Maximum points a participant can earn (default: 200)')
           .setRequired(false)
           .setMinValue(1),
       )
@@ -263,7 +262,6 @@ export default {
   data,
 
   async execute(interaction) {
-    // Handle autocomplete for event_name across all subcommands
     if (interaction.isAutocomplete()) {
       return handleEventNameAutocomplete(interaction);
     }

--- a/src/commands/event/event.js
+++ b/src/commands/event/event.js
@@ -1,0 +1,295 @@
+import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import createEvent from '../../service/interaction/is-chat-input-command/create-event.js';
+import editEvent from '../../service/interaction/is-chat-input-command/edit-event.js';
+import eventInfo from '../../service/interaction/is-chat-input-command/event-info.js';
+import eventLeaderboard from '../../service/interaction/is-chat-input-command/event-leaderboard.js';
+import eventExport from '../../service/interaction/is-chat-input-command/event-export.js';
+import eventRemove from '../../service/interaction/is-chat-input-command/event-remove.js';
+import {
+  eventPointsAdd,
+  eventPointsRemove,
+} from '../../service/interaction/is-chat-input-command/event-points.js';
+import {
+  eventParticipantRemove,
+  eventParticipantBan,
+} from '../../service/interaction/is-chat-input-command/event-participant.js';
+import channelLog, {
+  generateInteractionCreateLogContent,
+} from '../../service/utils/channel-log.js';
+import { handleEventNameAutocomplete } from '../../service/interaction/is-autocomplete/event-name-autocomplete.js';
+
+const EVENT_TYPES = [
+  { name: 'Reading', value: 'Reading' },
+  { name: 'Listening', value: 'Listening' },
+  { name: 'Speaking', value: 'Speaking' },
+  { name: 'Writing', value: 'Writing' },
+  { name: 'Live Event', value: 'Live Event' },
+  { name: 'Mixed', value: 'Mixed' },
+  { name: 'Other', value: 'Other' },
+];
+
+// Reusable autocomplete event name option
+const eventNameOption = (o) =>
+  o.setName('event_name').setDescription('Event name').setRequired(true).setAutocomplete(true);
+
+const data = new SlashCommandBuilder()
+  .setName('event')
+  .setDescription('Event management commands')
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents)
+
+  // ── /event create ──────────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('create')
+      .setDescription('Create a new event')
+      .addStringOption((o) =>
+        o.setName('name').setDescription('Event name').setRequired(true).setMaxLength(100),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('event_type')
+          .setDescription('Type of event')
+          .setRequired(true)
+          .addChoices(...EVENT_TYPES),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('hashtag')
+          .setDescription('Hashtag used to identify submissions (e.g. #SummerReads)')
+          .setRequired(true)
+          .setMaxLength(100),
+      )
+      .addChannelOption((o) =>
+        o
+          .setName('submission_channel')
+          .setDescription('Channel where submissions are tracked')
+          .setRequired(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('start_date')
+          .setDescription('Start date/time in UTC (YYYY-MM-DDTHH:MM or YYYY-MM-DD HH:MM)')
+          .setRequired(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('end_date')
+          .setDescription('End date/time in UTC (YYYY-MM-DDTHH:MM or YYYY-MM-DD HH:MM)')
+          .setRequired(true),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('points_per_submission')
+          .setDescription('Points awarded per valid submission (leave empty for tracking-only)')
+          .setRequired(false)
+          .setMinValue(1),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('max_points')
+          .setDescription('Maximum points a participant can earn (required if points set)')
+          .setRequired(false)
+          .setMinValue(1),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('creator_bonus')
+          .setDescription('Additional points added to creator total on export (0 = none)')
+          .setRequired(false)
+          .setMinValue(0),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('event_post_link')
+          .setDescription('Optional link to the original event post')
+          .setRequired(false),
+      ),
+  )
+
+  // ── /event edit ────────────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('edit')
+      .setDescription('Edit an existing event')
+      .addStringOption(eventNameOption)
+      .addStringOption((o) =>
+        o.setName('name').setDescription('New event name').setRequired(false).setMaxLength(100),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('event_type')
+          .setDescription('New event type')
+          .setRequired(false)
+          .addChoices(...EVENT_TYPES),
+      )
+      .addStringOption((o) =>
+        o.setName('hashtag').setDescription('New hashtag').setRequired(false).setMaxLength(100),
+      )
+      .addChannelOption((o) =>
+        o.setName('submission_channel').setDescription('New submission channel').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName('start_date').setDescription('New start date/time in UTC').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName('end_date').setDescription('New end date/time in UTC').setRequired(false),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('points_per_submission')
+          .setDescription('New points per submission')
+          .setRequired(false)
+          .setMinValue(1),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('max_points')
+          .setDescription('New maximum points')
+          .setRequired(false)
+          .setMinValue(1),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('creator_bonus')
+          .setDescription('New creator bonus (0 = none)')
+          .setRequired(false)
+          .setMinValue(0),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('event_post_link')
+          .setDescription('New event post link (leave blank to clear)')
+          .setRequired(false),
+      ),
+  )
+
+  // ── /event info ────────────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('info')
+      .setDescription('Show the details and status of an event')
+      .addStringOption(eventNameOption),
+  )
+
+  // ── /event leaderboard ─────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('leaderboard')
+      .setDescription("Post and pin the live leaderboard in the event's submission channel")
+      .addStringOption(eventNameOption),
+  )
+
+  // ── /event export ──────────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('export')
+      .setDescription('Generate t@scores point allocation commands for an event')
+      .addStringOption(eventNameOption),
+  )
+
+  // ── /event remove ──────────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('remove')
+      .setDescription('Permanently delete an event and all its data')
+      .addStringOption(eventNameOption),
+  )
+
+  // ── /event points ──────────────────────────────────────────────────────────
+  .addSubcommandGroup((group) =>
+    group
+      .setName('points')
+      .setDescription('Manually adjust participant points')
+      .addSubcommand((sub) =>
+        sub
+          .setName('add')
+          .setDescription('Add points to a participant')
+          .addStringOption(eventNameOption)
+          .addUserOption((o) =>
+            o.setName('user').setDescription('Target participant').setRequired(true),
+          )
+          .addIntegerOption((o) =>
+            o
+              .setName('amount')
+              .setDescription('Number of points to add')
+              .setRequired(true)
+              .setMinValue(1),
+          ),
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('remove')
+          .setDescription('Remove points from a participant')
+          .addStringOption(eventNameOption)
+          .addUserOption((o) =>
+            o.setName('user').setDescription('Target participant').setRequired(true),
+          )
+          .addIntegerOption((o) =>
+            o
+              .setName('amount')
+              .setDescription('Number of points to remove')
+              .setRequired(true)
+              .setMinValue(1),
+          ),
+      ),
+  )
+
+  // ── /event participant ─────────────────────────────────────────────────────
+  .addSubcommandGroup((group) =>
+    group
+      .setName('participant')
+      .setDescription('Manage event participants')
+      .addSubcommand((sub) =>
+        sub
+          .setName('remove')
+          .setDescription('Remove a participant and all their tracked event data')
+          .addStringOption(eventNameOption)
+          .addUserOption((o) =>
+            o.setName('user').setDescription('Participant to remove').setRequired(true),
+          ),
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('ban')
+          .setDescription('Prevent a participant from earning further points')
+          .addStringOption(eventNameOption)
+          .addUserOption((o) =>
+            o.setName('user').setDescription('Participant to ban').setRequired(true),
+          ),
+      ),
+  );
+
+export default {
+  data,
+
+  async execute(interaction) {
+    // Handle autocomplete for event_name across all subcommands
+    if (interaction.isAutocomplete()) {
+      return handleEventNameAutocomplete(interaction);
+    }
+
+    channelLog(generateInteractionCreateLogContent(interaction));
+
+    const sub = interaction.options.getSubcommand(false);
+    const group = interaction.options.getSubcommandGroup(false);
+
+    if (group === 'points') {
+      if (sub === 'add') return eventPointsAdd(interaction);
+      if (sub === 'remove') return eventPointsRemove(interaction);
+    }
+
+    if (group === 'participant') {
+      if (sub === 'remove') return eventParticipantRemove(interaction);
+      if (sub === 'ban') return eventParticipantBan(interaction);
+    }
+
+    if (sub === 'create') return createEvent(interaction);
+    if (sub === 'edit') return editEvent(interaction);
+    if (sub === 'info') return eventInfo(interaction);
+    if (sub === 'leaderboard') return eventLeaderboard(interaction);
+    if (sub === 'export') return eventExport(interaction);
+    if (sub === 'remove') return eventRemove(interaction);
+
+    return interaction.reply({ content: '❌ Unknown subcommand.', ephemeral: true });
+  },
+};

--- a/src/commands/live-event/live-event.js
+++ b/src/commands/live-event/live-event.js
@@ -1,0 +1,225 @@
+import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import liveEventCreate from '../../service/interaction/is-chat-input-command/live-event-create.js';
+import liveEventEdit from '../../service/interaction/is-chat-input-command/live-event-edit.js';
+import liveEventInfo from '../../service/interaction/is-chat-input-command/live-event-info.js';
+import liveEventRemove from '../../service/interaction/is-chat-input-command/live-event-remove.js';
+import liveEventSkip from '../../service/interaction/is-chat-input-command/live-event-skip.js';
+import liveEventUnskip from '../../service/interaction/is-chat-input-command/live-event-unskip.js';
+import liveEventReschedule from '../../service/interaction/is-chat-input-command/live-event-reschedule.js';
+import channelLog, {
+  generateInteractionCreateLogContent,
+} from '../../service/utils/channel-log.js';
+import { handleLiveEventNameAutocomplete } from '../../service/interaction/is-autocomplete/live-event-name-autocomplete.js';
+
+const liveEventNameOption = (o) =>
+  o.setName('event_name').setDescription('Live event name').setRequired(true).setAutocomplete(true);
+
+const data = new SlashCommandBuilder()
+  .setName('live-event')
+  .setDescription('Manage live and recurring events')
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageEvents)
+
+  // ── /live-event create ─────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('create')
+      .setDescription('Create a one-time or recurring live event')
+      .addStringOption((o) =>
+        o.setName('name').setDescription('Event name').setRequired(true).setMaxLength(100),
+      )
+      .addChannelOption((o) =>
+        o
+          .setName('location')
+          .setDescription('Channel where the event takes place (voice, stage, text, etc.)')
+          .setRequired(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('schedule_type')
+          .setDescription('One-time or recurring schedule')
+          .setRequired(true)
+          .addChoices(
+            { name: 'One-time', value: 'one-time' },
+            { name: 'Recurring', value: 'recurring' },
+          ),
+      )
+      .addUserOption((o) =>
+        o.setName('host').setDescription('Primary host of the event').setRequired(false),
+      )
+      .addUserOption((o) =>
+        o.setName('host_2').setDescription('Additional host').setRequired(false),
+      )
+      .addUserOption((o) =>
+        o.setName('host_3').setDescription('Additional host').setRequired(false),
+      ),
+  )
+
+  // ── /live-event edit ───────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('edit')
+      .setDescription('Edit live event details or its recurring schedule')
+      .addStringOption(liveEventNameOption)
+      .addStringOption((o) =>
+        o.setName('name').setDescription('New event name').setRequired(false).setMaxLength(100),
+      )
+      .addChannelOption((o) =>
+        o.setName('location').setDescription('New location channel').setRequired(false),
+      )
+      .addUserOption((o) => o.setName('host').setDescription('New primary host').setRequired(false))
+      .addUserOption((o) =>
+        o.setName('host_2').setDescription('New additional host').setRequired(false),
+      )
+      .addUserOption((o) =>
+        o.setName('host_3').setDescription('New additional host').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('event_post_link')
+          .setDescription('New event post link (leave blank to clear)')
+          .setRequired(false),
+      ),
+  )
+
+  // ── /live-event info ───────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('info')
+      .setDescription('Display live event details, schedule, and next occurrence')
+      .addStringOption(liveEventNameOption),
+  )
+
+  // ── /live-event remove ─────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('remove')
+      .setDescription('Permanently remove a live event and all its data')
+      .addStringOption(liveEventNameOption),
+  )
+
+  // ── /live-event skip ───────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('skip')
+      .setDescription('Cancel one or more scheduled occurrences without changing the schedule')
+      .addStringOption(liveEventNameOption)
+      .addStringOption((o) =>
+        o
+          .setName('date')
+          .setDescription('Date of the occurrence to skip (YYYY-MM-DD)')
+          .setRequired(true)
+          .setMaxLength(10),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('start_time')
+          .setDescription('Start time of the slot (HH:MM) — required if multiple slots on same day')
+          .setRequired(false)
+          .setMaxLength(5),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('end_date')
+          .setDescription('Skip all occurrences from date through this date (YYYY-MM-DD)')
+          .setRequired(false)
+          .setMaxLength(10),
+      ),
+  )
+
+  // ── /live-event unskip ─────────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('unskip')
+      .setDescription('Restore a previously skipped occurrence')
+      .addStringOption(liveEventNameOption)
+      .addStringOption((o) =>
+        o
+          .setName('date')
+          .setDescription('Date of the skipped occurrence to restore (YYYY-MM-DD)')
+          .setRequired(true)
+          .setMaxLength(10),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('start_time')
+          .setDescription('Start time of the slot (HH:MM) — required if multiple slots on same day')
+          .setRequired(false)
+          .setMaxLength(5),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('end_date')
+          .setDescription(
+            'Restore all skipped occurrences from date through this date (YYYY-MM-DD)',
+          )
+          .setRequired(false)
+          .setMaxLength(10),
+      ),
+  )
+
+  // ── /live-event reschedule ─────────────────────────────────────────────────
+  .addSubcommand((sub) =>
+    sub
+      .setName('reschedule')
+      .setDescription('Move one scheduled occurrence to a different date/time')
+      .addStringOption(liveEventNameOption)
+      .addStringOption((o) =>
+        o
+          .setName('occurrence_date')
+          .setDescription('Date of the scheduled occurrence you want to move (YYYY-MM-DD)')
+          .setRequired(true)
+          .setMaxLength(10),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('new_date')
+          .setDescription('New date for this occurrence (YYYY-MM-DD)')
+          .setRequired(true)
+          .setMaxLength(10),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('new_start_time')
+          .setDescription('New start time for this occurrence in UTC (HH:MM)')
+          .setRequired(true)
+          .setMaxLength(5),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('new_end_time')
+          .setDescription('New end time for this occurrence in UTC (HH:MM)')
+          .setRequired(true)
+          .setMaxLength(5),
+          )
+      .addStringOption((o) =>
+        o
+          .setName('occurrence_start_time')
+          .setDescription('Start time of the occurrence you want to move (HH:MM, if needed)')
+          .setRequired(false)
+          .setMaxLength(5),
+          ),
+  );
+
+export default {
+  data,
+
+  async execute(interaction) {
+    if (interaction.isAutocomplete()) {
+      return handleLiveEventNameAutocomplete(interaction);
+    }
+
+    channelLog(generateInteractionCreateLogContent(interaction));
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'create') return liveEventCreate(interaction);
+    if (sub === 'edit') return liveEventEdit(interaction);
+    if (sub === 'info') return liveEventInfo(interaction);
+    if (sub === 'remove') return liveEventRemove(interaction);
+    if (sub === 'skip') return liveEventSkip(interaction);
+    if (sub === 'unskip') return liveEventUnskip(interaction);
+    if (sub === 'reschedule') return liveEventReschedule(interaction);
+
+    return interaction.reply({ content: '❌ Unknown subcommand.', ephemeral: true });
+  },
+};

--- a/src/data/emoji-keywords.js
+++ b/src/data/emoji-keywords.js
@@ -497,11 +497,9 @@ export default {
   // Symbols & Effects
   '✨': ['sparkles', 'magic', 'shiny', 'glitter', 'special'],
   '🌟': ['glowing', 'star', 'bright', 'shine', 'special'],
-  '💫': ['dizzy', 'star', 'sparkle', 'magic', 'wonder'],
   '⚡': ['high', 'voltage', 'lightning', 'electric', 'power'],
   '☀️': ['sun', 'sunny', 'bright', 'day', 'weather'],
   '🌙': ['crescent', 'moon', 'night', 'sleep', 'lunar'],
-  '🌛': ['first', 'quarter', 'moon', 'face', 'night'],
   '🌜': ['last', 'quarter', 'moon', 'face', 'night'],
   '🌚': ['new', 'moon', 'face', 'dark', 'creepy'],
   '🌝': ['full', 'moon', 'face', 'bright', 'night'],

--- a/src/events/interaction-create.js
+++ b/src/events/interaction-create.js
@@ -16,10 +16,17 @@ import {
   handleEventRemoveConfirm,
   handleEventRemoveCancel,
 } from '../service/interaction/is-chat-input-command/event-remove.js';
+import { handleLiveEventCreateModalSubmit } from '../service/interaction/is-chat-input-command/live-event-create.js';
+import { handleLiveEventEditModalSubmit } from '../service/interaction/is-chat-input-command/live-event-edit.js';
+import {
+  handleLiveEventRemoveConfirm,
+  handleLiveEventRemoveCancel,
+} from '../service/interaction/is-chat-input-command/live-event-remove.js';
 
 export default {
   name: Events.InteractionCreate,
   async execute(interaction) {
+    // ── Autocomplete ──────────────────────────────────────────────────────────
     if (interaction.isAutocomplete()) {
       channelLog(
         generateInteractionCreateLogContent(
@@ -32,11 +39,16 @@ export default {
         trackerJoinEmojiAutocomplete(interaction);
         return;
       }
-
       if (interaction.commandName === 'event') {
         const { handleEventNameAutocomplete } =
           await import('../service/interaction/is-autocomplete/event-name-autocomplete.js');
         handleEventNameAutocomplete(interaction);
+        return;
+      }
+      if (interaction.commandName === 'live-event') {
+        const { handleLiveEventNameAutocomplete } =
+          await import('../service/interaction/is-autocomplete/live-event-name-autocomplete.js');
+        handleLiveEventNameAutocomplete(interaction);
         return;
       }
     }
@@ -46,6 +58,7 @@ export default {
       if (cooldownRes?.shouldReturn) return;
     }
 
+    // ── Modal submits ─────────────────────────────────────────────────────────
     if (interaction.isModalSubmit()) {
       channelLog(
         generateInteractionCreateLogContent(
@@ -54,37 +67,41 @@ export default {
         ),
       );
 
+      if (interaction.customId.startsWith('live-event-create-modal\x00')) {
+        handleLiveEventCreateModalSubmit(interaction);
+        return;
+      }
+      if (interaction.customId.startsWith('live-event-edit-modal\x00')) {
+        handleLiveEventEditModalSubmit(interaction);
+        return;
+      }
       if (interaction.customId === 'generate-poll') {
         GeneratePollModalSubmit(interaction);
         return;
       }
-
       if (interaction.customId === 'register-my-exchange-listing') {
         RegisterExchangePartnerListModalSubmit(interaction);
         return;
       }
-
       if (interaction.customId === 'register-my-study-buddy-listing') {
         registerMyStudyBuddyListing(interaction);
         return;
       }
-
       if (interaction.customId === 'create-new-category') {
         createNewCategory(interaction);
         return;
       }
-
       if (interaction.customId === 'create-a-new-match-match-topic') {
         createANewMatchMatchTopic(interaction);
         return;
       }
-
       if (interaction.customId === 'participate-match-match') {
         participateMatchMatch(interaction);
         return;
       }
     }
 
+    // ── Buttons ───────────────────────────────────────────────────────────────
     if (interaction.isButton()) {
       channelLog(
         generateInteractionCreateLogContent(
@@ -97,31 +114,33 @@ export default {
         getExchangeListing(interaction);
         return;
       }
-
       if (interaction.customId.startsWith('get-study-buddy')) {
         getStudyBuddyListing(interaction);
         return;
       }
-
       if (interaction.customId.startsWith('join-pomodoro-group')) {
         joinPomodoroGroup(interaction);
         return;
       }
-
       if (interaction.customId.startsWith('dm-server-tutorial')) {
         dmServerTutorial(interaction);
         // eslint-disable-next-line no-useless-return
         return;
       }
-
       if (interaction.customId.startsWith('event-remove-confirm:')) {
         handleEventRemoveConfirm(interaction);
         return;
       }
-
       if (interaction.customId.startsWith('event-remove-cancel:')) {
         handleEventRemoveCancel(interaction);
         return;
+      }
+      if (interaction.customId.startsWith('live-event-remove-confirm:')) {
+        handleLiveEventRemoveConfirm(interaction);
+        return;
+      }
+      if (interaction.customId.startsWith('live-event-remove-cancel:')) {
+        handleLiveEventRemoveCancel(interaction);
       }
     }
   },

--- a/src/events/interaction-create.js
+++ b/src/events/interaction-create.js
@@ -12,6 +12,10 @@ import createANewMatchMatchTopic from '../service/interaction/is-modal-submit/cr
 import participateMatchMatch from '../service/interaction/is-modal-submit/participate-match-match.js';
 import trackerJoinEmojiAutocomplete from '../service/interaction/is-autocomplete/tracker-join-emoji-autocomplete.js';
 import dmServerTutorial from '../service/interaction/is-button/dm-server-tutorial.js';
+import {
+  handleEventRemoveConfirm,
+  handleEventRemoveCancel,
+} from '../service/interaction/is-chat-input-command/event-remove.js';
 
 export default {
   name: Events.InteractionCreate,
@@ -26,6 +30,13 @@ export default {
 
       if (interaction.commandName === 'tracker-join') {
         trackerJoinEmojiAutocomplete(interaction);
+        return;
+      }
+
+      if (interaction.commandName === 'event') {
+        const { handleEventNameAutocomplete } =
+          await import('../service/interaction/is-autocomplete/event-name-autocomplete.js');
+        handleEventNameAutocomplete(interaction);
         return;
       }
     }
@@ -100,6 +111,16 @@ export default {
       if (interaction.customId.startsWith('dm-server-tutorial')) {
         dmServerTutorial(interaction);
         // eslint-disable-next-line no-useless-return
+        return;
+      }
+
+      if (interaction.customId.startsWith('event-remove-confirm:')) {
+        handleEventRemoveConfirm(interaction);
+        return;
+      }
+
+      if (interaction.customId.startsWith('event-remove-cancel:')) {
+        handleEventRemoveCancel(interaction);
         return;
       }
     }

--- a/src/events/message-create.js
+++ b/src/events/message-create.js
@@ -4,6 +4,7 @@ import suggestionBoxMessageCreate from '../service/messageCreate/suggestion-box.
 import passTheCoffeeCup from '../service/messageCreate/pass-the-coffee-cup.js';
 import passTheEmoji from '../service/messageCreate/emoji-blend.js';
 import trackerCheckin from '../service/messageCreate/tracker-checkin.js';
+import eventSubmission from '../service/messageCreate/event-submission.js';
 import config from '../config/index.js';
 import categories from '../service/messageCreate/categories.js';
 import counting from '../service/messageCreate/counting.js';
@@ -31,6 +32,9 @@ export default {
       trackerCheckin(message);
       return;
     }
+
+    // Event submission tracking (checks all messages for active event hashtags)
+    eventSubmission(message);
 
     // #study-check-in
     if (message.channel.id === studyCheckInChannelId) {

--- a/src/models/event-ban.js
+++ b/src/models/event-ban.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const eventBan = new Schema(
+  {
+    eventId: {
+      type: String,
+      required: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+    // Moderator who issued the ban
+    bannedBy: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  },
+);
+
+// One ban record per user per event
+eventBan.index({ eventId: 1, userId: 1 }, { unique: true });
+eventBan.index({ eventId: 1 });
+
+export default mongoose.model('event-ban', eventBan);

--- a/src/models/event-leaderboard.js
+++ b/src/models/event-leaderboard.js
@@ -1,0 +1,36 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+// Tracks the pinned leaderboard message for an event.
+// One record per event — created when /event leaderboard is run.
+const eventLeaderboard = new Schema(
+  {
+    eventId: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    // The channel where the leaderboard message was posted
+    channelId: {
+      type: String,
+      required: true,
+    },
+    // The pinned message ID — used to edit the embed on every submission
+    messageId: {
+      type: String,
+      required: true,
+    },
+    // Once 3 participants hit max points, no further edits are made
+    isLocked: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  },
+);
+
+export default mongoose.model('event-leaderboard', eventLeaderboard);

--- a/src/models/event-participant.js
+++ b/src/models/event-participant.js
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const eventParticipant = new Schema(
+  {
+    eventId: {
+      type: String,
+      required: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+    // Total points earned from submissions (capped at maxPoints)
+    points: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    // Number of valid submissions counted
+    submissionCount: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  },
+);
+
+// One record per user per event
+eventParticipant.index({ eventId: 1, userId: 1 }, { unique: true });
+eventParticipant.index({ eventId: 1 });
+// For leaderboard queries: sort by points descending
+eventParticipant.index({ eventId: 1, points: -1 });
+
+export default mongoose.model('event-participant', eventParticipant);

--- a/src/models/event-submission.js
+++ b/src/models/event-submission.js
@@ -1,0 +1,42 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+// Tracks individual messages counted as submissions, so the same message
+// is never counted more than once for the same event.
+const eventSubmission = new Schema(
+  {
+    eventId: {
+      type: String,
+      required: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+    // Discord message ID — used for deduplication
+    messageId: {
+      type: String,
+      required: true,
+    },
+    channelId: {
+      type: String,
+      required: true,
+    },
+    pointsAwarded: {
+      type: Number,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  },
+);
+
+// Unique per message per event (one message can only count once per event)
+eventSubmission.index({ eventId: 1, messageId: 1 }, { unique: true });
+eventSubmission.index({ eventId: 1, userId: 1 });
+eventSubmission.index({ eventId: 1 });
+
+export default mongoose.model('event-submission', eventSubmission);

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -10,14 +10,13 @@ const eventSchema = new Schema(
     },
     eventType: {
       type: String,
-      enum: ['Reading', 'Listening', 'Speaking', 'Writing', 'Live Event', 'Mixed', 'Other'],
+      enum: ['Reading', 'Listening', 'Speaking', 'Writing', 'Mixed', 'Other'],
       required: true,
     },
     hashtag: {
       type: String,
       required: true,
     },
-    // Single channel where submissions are tracked
     submissionChannelId: {
       type: String,
       required: true,
@@ -36,7 +35,7 @@ const eventSchema = new Schema(
       default: null,
       min: 1,
     },
-    // Optional — required only when pointsPerSubmission is set
+    // Optional — defaults to 200 when points_per_submission is set
     maxPoints: {
       type: Number,
       default: null,
@@ -48,17 +47,14 @@ const eventSchema = new Schema(
       default: 0,
       min: 0,
     },
-    // Optional link to the original event post
     eventPostLink: {
       type: String,
       default: null,
     },
-    // Discord user ID of the event creator
     creatorId: {
       type: String,
       required: true,
     },
-    // Status: pending → active → ended
     status: {
       type: String,
       enum: ['pending', 'active', 'ended'],
@@ -75,7 +71,6 @@ eventSchema.index({ status: 1 });
 eventSchema.index({ status: 1, startDate: 1 });
 eventSchema.index({ status: 1, endDate: 1 });
 eventSchema.index({ status: 1, submissionChannelId: 1 });
-// For name autocomplete
 eventSchema.index({ name: 'text' });
 
 export default mongoose.model('event', eventSchema);

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -1,0 +1,81 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const eventSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+    },
+    eventType: {
+      type: String,
+      enum: ['Reading', 'Listening', 'Speaking', 'Writing', 'Live Event', 'Mixed', 'Other'],
+      required: true,
+    },
+    hashtag: {
+      type: String,
+      required: true,
+    },
+    // Single channel where submissions are tracked
+    submissionChannelId: {
+      type: String,
+      required: true,
+    },
+    startDate: {
+      type: Date,
+      required: true,
+    },
+    endDate: {
+      type: Date,
+      required: true,
+    },
+    // Optional — if null, submissions are tracked but no points are awarded
+    pointsPerSubmission: {
+      type: Number,
+      default: null,
+      min: 1,
+    },
+    // Optional — required only when pointsPerSubmission is set
+    maxPoints: {
+      type: Number,
+      default: null,
+      min: 1,
+    },
+    // 0 means no bonus
+    creatorBonus: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    // Optional link to the original event post
+    eventPostLink: {
+      type: String,
+      default: null,
+    },
+    // Discord user ID of the event creator
+    creatorId: {
+      type: String,
+      required: true,
+    },
+    // Status: pending → active → ended
+    status: {
+      type: String,
+      enum: ['pending', 'active', 'ended'],
+      default: 'pending',
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  },
+);
+
+eventSchema.index({ status: 1 });
+eventSchema.index({ status: 1, startDate: 1 });
+eventSchema.index({ status: 1, endDate: 1 });
+eventSchema.index({ status: 1, submissionChannelId: 1 });
+// For name autocomplete
+eventSchema.index({ name: 'text' });
+
+export default mongoose.model('event', eventSchema);

--- a/src/models/live-event.js
+++ b/src/models/live-event.js
@@ -1,0 +1,91 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const scheduleSlotSchema = new Schema(
+  {
+    // 0 = Sunday … 6 = Saturday
+    dayOfWeek: { type: Number, required: true, min: 0, max: 6 },
+    startTime: { type: String, required: true }, // "HH:MM" UTC
+    endTime: { type: String, required: true }, // "HH:MM" UTC
+  },
+  { _id: false },
+);
+
+const skippedOccurrenceSchema = new Schema(
+  {
+    date: { type: String, required: true }, // "YYYY-MM-DD"
+    startTime: { type: String, required: true }, // "HH:MM" — identifies the slot
+    skippedBy: { type: String, required: true }, // Discord user ID
+    skippedAt: { type: Date, default: () => new Date() },
+  },
+  { _id: false },
+);
+
+const rescheduledOccurrenceSchema = new Schema(
+  {
+    originalDate: { type: String, required: true }, // "YYYY-MM-DD"
+    originalStartTime: { type: String, required: true }, // "HH:MM"
+    newDate: { type: String, required: true }, // "YYYY-MM-DD"
+    newStartTime: { type: String, required: true }, // "HH:MM"
+    newEndTime: { type: String, required: true }, // "HH:MM"
+    rescheduledBy: { type: String, required: true }, // Discord user ID
+    rescheduledAt: { type: Date, default: () => new Date() },
+  },
+  { _id: false },
+);
+
+const liveEventSchema = new Schema(
+  {
+    name: { type: String, required: true },
+
+    // Host Discord user IDs
+    hostIds: { type: [String], default: [] },
+
+    // Discord channel ID where the event takes place
+    locationChannelId: { type: String, required: true },
+
+    // Optional link to the event announcement post (Discord message link or URL)
+    eventPostLink: { type: String, default: null },
+
+    // ── Schedule ─────────────────────────────────────────────────────────────
+    scheduleType: {
+      type: String,
+      enum: ['one-time', 'recurring'],
+      required: true,
+    },
+
+    // One-time fields
+    oneTimeDate: { type: String, default: null }, // "YYYY-MM-DD"
+    oneTimeStartTime: { type: String, default: null }, // "HH:MM"
+    oneTimeEndTime: { type: String, default: null }, // "HH:MM"
+
+    // Recurring fields
+    recurrenceStartDate: { type: String, default: null }, // "YYYY-MM-DD"
+    recurrenceEndDate: { type: String, default: null }, // "YYYY-MM-DD"
+    slots: { type: [scheduleSlotSchema], default: [] },
+
+    // ── Exceptions ────────────────────────────────────────────────────────────
+    skippedOccurrences: { type: [skippedOccurrenceSchema], default: [] },
+    rescheduledOccurrences: { type: [rescheduledOccurrenceSchema], default: [] },
+
+    // ── Meta ──────────────────────────────────────────────────────────────────
+    creatorId: { type: String, required: true },
+
+    // upcoming → live (during an occurrence) → ended (no future occurrences)
+    status: {
+      type: String,
+      enum: ['upcoming', 'live', 'ended'],
+      default: 'upcoming',
+    },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+  },
+);
+
+liveEventSchema.index({ status: 1 });
+liveEventSchema.index({ name: 'text' });
+
+export default mongoose.model('live-event', liveEventSchema);

--- a/src/schedules/index.js
+++ b/src/schedules/index.js
@@ -7,12 +7,17 @@ import trackerDailyMaintenance from '../service/schedules/tracker-daily-maintena
 import trackerWeeklySnapshots from '../service/schedules/tracker-weekly-snapshots.js';
 import trackerDailyReminders from '../service/schedules/tracker-daily-reminders.js';
 import eventLifecycle from '../service/schedules/event-lifecycle.js';
+import { refreshEventCalendar } from '../service/utils/event-calendar.js';
 
 export default function schedules() {
   // every 10 seconds
   // schedule.scheduleJob('*/10 * * * * *', async () => {
 
   // });
+
+  // Run immediately on startup to catch any state changes while the bot was down
+  eventLifecycle();
+  refreshEventCalendar();
 
   // every hour
   schedule.scheduleJob('0 * * * *', () => {
@@ -26,6 +31,8 @@ export default function schedules() {
     sendANewMatchMatchMessage();
     trackerDailyMaintenance();
     trackerDailyReminders();
+    // Refresh calendar daily so date headings stay current
+    refreshEventCalendar();
   });
 
   // every Sunday at 01:00 (weekly snapshots)

--- a/src/schedules/index.js
+++ b/src/schedules/index.js
@@ -6,6 +6,7 @@ import checkAndSendReminders from '../service/schedules/check-and-send-reminders
 import trackerDailyMaintenance from '../service/schedules/tracker-daily-maintenance.js';
 import trackerWeeklySnapshots from '../service/schedules/tracker-weekly-snapshots.js';
 import trackerDailyReminders from '../service/schedules/tracker-daily-reminders.js';
+import eventLifecycle from '../service/schedules/event-lifecycle.js';
 
 export default function schedules() {
   // every 10 seconds
@@ -17,6 +18,7 @@ export default function schedules() {
   schedule.scheduleJob('0 * * * *', () => {
     checkIfPassTheCoffeeCupLastMessageIsValid();
     checkAndSendReminders();
+    eventLifecycle();
   });
 
   // every day at 00:00

--- a/src/service/interaction/is-autocomplete/event-name-autocomplete.js
+++ b/src/service/interaction/is-autocomplete/event-name-autocomplete.js
@@ -1,0 +1,28 @@
+import Event from '../../../models/event.js';
+
+/**
+ * Autocomplete handler for the `event_name` option.
+ * Returns up to 25 events whose names start with (or contain) the typed value.
+ * Shows all non-removed events (pending, active, ended).
+ */
+export async function handleEventNameAutocomplete(interaction) {
+  try {
+    const focused = interaction.options.getFocused();
+
+    const query = focused ? { name: { $regex: new RegExp(focused, 'i') } } : {};
+
+    const events = await Event.find(query).sort({ startDate: -1 }).limit(25).select('name status');
+
+    const statusEmoji = { active: '🟢', pending: '🕐', ended: '⚫' };
+
+    const choices = events.map((e) => ({
+      name: `${statusEmoji[e.status] ?? ''} ${e.name}`.trim(),
+      value: e.name,
+    }));
+
+    await interaction.respond(choices);
+  } catch (err) {
+    console.error('Error in event name autocomplete:', err);
+    await interaction.respond([]);
+  }
+}

--- a/src/service/interaction/is-autocomplete/event-name-autocomplete.js
+++ b/src/service/interaction/is-autocomplete/event-name-autocomplete.js
@@ -1,4 +1,6 @@
 import Event from '../../../models/event.js';
+import queryWithTimeout from '../../utils/query-with-timeout.js';
+import { escapeRegex } from '../../utils/event-utils.js';
 
 /**
  * Autocomplete handler for the `event_name` option.
@@ -9,20 +11,26 @@ export async function handleEventNameAutocomplete(interaction) {
   try {
     const focused = interaction.options.getFocused();
 
-    const query = focused ? { name: { $regex: new RegExp(focused, 'i') } } : {};
+    const query = focused ? { name: { $regex: new RegExp(escapeRegex(focused), 'i') } } : {};
 
-    const events = await Event.find(query).sort({ startDate: -1 }).limit(25).select('name status');
+    const events =
+      (await queryWithTimeout(
+        Event.find(query)
+          .sort({ startDate: -1 })
+          .limit(25)
+          .select('name status')
+          .lean(),
+      )) ?? [];
 
     const statusEmoji = { active: '🟢', pending: '🕐', ended: '⚫' };
 
     const choices = events.map((e) => ({
       name: `${statusEmoji[e.status] ?? ''} ${e.name}`.trim(),
-      value: e.name,
+      value: e._id.toString(),
     }));
 
     await interaction.respond(choices);
   } catch (err) {
     console.error('Error in event name autocomplete:', err);
-    await interaction.respond([]);
   }
 }

--- a/src/service/interaction/is-autocomplete/live-event-name-autocomplete.js
+++ b/src/service/interaction/is-autocomplete/live-event-name-autocomplete.js
@@ -1,0 +1,37 @@
+import LiveEvent from '../../../models/live-event.js';
+import { computeLiveEventStatus } from '../../utils/live-event-utils.js';
+import { escapeRegex } from '../../utils/event-utils.js';
+import queryWithTimeout from '../../utils/query-with-timeout.js';
+
+/**
+ * Autocomplete handler for live event name fields.
+ * Returns up to 25 matching live events with explicit schedule and status labels.
+ */
+export async function handleLiveEventNameAutocomplete(interaction) {
+  const focused = interaction.options.getFocused();
+
+  const events =
+    (await queryWithTimeout(
+      LiveEvent.find({ name: { $regex: new RegExp(escapeRegex(focused), 'i') } })
+        .limit(25)
+        .lean(),
+    )) ?? [];
+
+  const STATUS_LABEL = {
+    upcoming: 'Upcoming',
+    live: 'Live now',
+    ended: 'Ended',
+  };
+
+  await interaction.respond(
+    events.map((event) => {
+      const status = computeLiveEventStatus(event);
+      const frequency = event.scheduleType === 'recurring' ? 'Recurring' : 'One-time';
+
+      return {
+        name: `${event.name} [${frequency} · ${STATUS_LABEL[status] ?? 'Unknown status'}]`,
+        value: event._id.toString(),
+      };
+    }),
+  );
+}

--- a/src/service/interaction/is-chat-input-command/create-event.js
+++ b/src/service/interaction/is-chat-input-command/create-event.js
@@ -16,26 +16,28 @@ export default async function createEvent(interaction) {
   const startDateStr = interaction.options.getString('start_date');
   const endDateStr = interaction.options.getString('end_date');
   const pointsPerSubmission = interaction.options.getInteger('points_per_submission') ?? null;
-  const maxPoints = interaction.options.getInteger('max_points') ?? null;
+  const maxPoints =
+    interaction.options.getInteger('max_points') ?? (pointsPerSubmission ? 200 : null);
   const creatorBonus = interaction.options.getInteger('creator_bonus') ?? 0;
   const eventPostLink = interaction.options.getString('event_post_link') ?? null;
 
-  // If one of points/maxPoints is set, both must be set
-  if ((pointsPerSubmission === null) !== (maxPoints === null)) {
+  // If points_per_submission is set, max_points defaults to 200 but can be overridden.
+  // If neither is set, both remain null (tracking-only mode).
+  if (pointsPerSubmission !== null && maxPoints === null) {
     return interaction.editReply(
-      '❌ `points_per_submission` and `max_points` must both be set or both left empty.',
+      '❌ `max_points` is required when `points_per_submission` is set.',
     );
   }
 
   const startDate = new Date(startDateStr);
   const endDate = new Date(endDateStr);
 
-  if (isNaN(startDate.getTime())) {
+  if (Number.isNaN(startDate.getTime())) {
     return interaction.editReply(
       '❌ Invalid start date. Use UTC format: `YYYY-MM-DDTHH:MM` or `YYYY-MM-DD HH:MM`.',
     );
   }
-  if (isNaN(endDate.getTime())) {
+  if (Number.isNaN(endDate.getTime())) {
     return interaction.editReply(
       '❌ Invalid end date. Use UTC format: `YYYY-MM-DDTHH:MM` or `YYYY-MM-DD HH:MM`.',
     );
@@ -64,8 +66,7 @@ export default async function createEvent(interaction) {
 
   await event.save();
 
-  // Refresh the calendar channel
-  refreshEventCalendar();
+  await refreshEventCalendar();
 
   channelLog(
     generateSystemLogContent('Event Created', {

--- a/src/service/interaction/is-chat-input-command/create-event.js
+++ b/src/service/interaction/is-chat-input-command/create-event.js
@@ -1,6 +1,7 @@
 import Event from '../../../models/event.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
 import { normaliseHashtag } from '../../utils/event-utils.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
 
 /**
  * /event create
@@ -62,6 +63,9 @@ export default async function createEvent(interaction) {
   });
 
   await event.save();
+
+  // Refresh the calendar channel
+  refreshEventCalendar();
 
   channelLog(
     generateSystemLogContent('Event Created', {

--- a/src/service/interaction/is-chat-input-command/create-event.js
+++ b/src/service/interaction/is-chat-input-command/create-event.js
@@ -1,0 +1,86 @@
+import Event from '../../../models/event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { normaliseHashtag } from '../../utils/event-utils.js';
+
+/**
+ * /event create
+ */
+export default async function createEvent(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const name = interaction.options.getString('name');
+  const eventType = interaction.options.getString('event_type');
+  const hashtag = normaliseHashtag(interaction.options.getString('hashtag'));
+  const submissionChannel = interaction.options.getChannel('submission_channel');
+  const startDateStr = interaction.options.getString('start_date');
+  const endDateStr = interaction.options.getString('end_date');
+  const pointsPerSubmission = interaction.options.getInteger('points_per_submission') ?? null;
+  const maxPoints = interaction.options.getInteger('max_points') ?? null;
+  const creatorBonus = interaction.options.getInteger('creator_bonus') ?? 0;
+  const eventPostLink = interaction.options.getString('event_post_link') ?? null;
+
+  // If one of points/maxPoints is set, both must be set
+  if ((pointsPerSubmission === null) !== (maxPoints === null)) {
+    return interaction.editReply(
+      '❌ `points_per_submission` and `max_points` must both be set or both left empty.',
+    );
+  }
+
+  const startDate = new Date(startDateStr);
+  const endDate = new Date(endDateStr);
+
+  if (isNaN(startDate.getTime())) {
+    return interaction.editReply(
+      '❌ Invalid start date. Use UTC format: `YYYY-MM-DDTHH:MM` or `YYYY-MM-DD HH:MM`.',
+    );
+  }
+  if (isNaN(endDate.getTime())) {
+    return interaction.editReply(
+      '❌ Invalid end date. Use UTC format: `YYYY-MM-DDTHH:MM` or `YYYY-MM-DD HH:MM`.',
+    );
+  }
+  if (endDate <= startDate) {
+    return interaction.editReply('❌ End date must be after start date.');
+  }
+
+  const now = new Date();
+  const status = startDate <= now ? 'active' : 'pending';
+
+  const event = new Event({
+    name,
+    eventType,
+    hashtag,
+    submissionChannelId: submissionChannel.id,
+    startDate,
+    endDate,
+    pointsPerSubmission,
+    maxPoints,
+    creatorBonus,
+    eventPostLink,
+    creatorId: interaction.user.id,
+    status,
+  });
+
+  await event.save();
+
+  channelLog(
+    generateSystemLogContent('Event Created', {
+      event: `\`${event.name}\``,
+      id: `\`${event._id}\``,
+      type: `\`${event.eventType}\``,
+      hashtag: `\`${event.hashtag}\``,
+      channel: `<#${submissionChannel.id}>`,
+      status: `\`${status}\``,
+      creator: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  const pointsInfo = pointsPerSubmission
+    ? `${pointsPerSubmission} pts/submission · max ${maxPoints} pts`
+    : 'No points (tracking only)';
+
+  return interaction.editReply(
+    `✅ Event **${name}** created (ID: \`${event._id}\`).\n` +
+      `Channel: <#${submissionChannel.id}> · ${pointsInfo}`,
+  );
+}

--- a/src/service/interaction/is-chat-input-command/edit-event.js
+++ b/src/service/interaction/is-chat-input-command/edit-event.js
@@ -1,6 +1,7 @@
 import Event from '../../../models/event.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
 import { normaliseHashtag } from '../../utils/event-utils.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
 
 /**
  * /event edit
@@ -95,6 +96,9 @@ export default async function editEvent(interaction) {
   }
 
   const updated = await Event.findByIdAndUpdate(event._id, updates, { new: true });
+
+  // Refresh the calendar channel
+  refreshEventCalendar();
 
   channelLog(
     generateSystemLogContent('Event Edited', {

--- a/src/service/interaction/is-chat-input-command/edit-event.js
+++ b/src/service/interaction/is-chat-input-command/edit-event.js
@@ -1,0 +1,109 @@
+import Event from '../../../models/event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { normaliseHashtag } from '../../utils/event-utils.js';
+
+/**
+ * /event edit
+ * Updates any provided fields and saves. Event is looked up by name (case-insensitive).
+ */
+export default async function editEvent(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+
+  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+
+  if (!event) {
+    return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+  }
+
+  const updates = {};
+  const changed = [];
+
+  const name = interaction.options.getString('name');
+  if (name) {
+    updates.name = name;
+    changed.push('name');
+  }
+
+  const eventType = interaction.options.getString('event_type');
+  if (eventType) {
+    updates.eventType = eventType;
+    changed.push('event_type');
+  }
+
+  const rawHashtag = interaction.options.getString('hashtag');
+  if (rawHashtag) {
+    updates.hashtag = normaliseHashtag(rawHashtag);
+    changed.push('hashtag');
+  }
+
+  const submissionChannel = interaction.options.getChannel('submission_channel');
+  if (submissionChannel) {
+    updates.submissionChannelId = submissionChannel.id;
+    changed.push('submission_channel');
+  }
+
+  const startDateStr = interaction.options.getString('start_date');
+  if (startDateStr) {
+    const d = new Date(startDateStr);
+    if (isNaN(d.getTime())) return interaction.editReply('❌ Invalid start date.');
+    updates.startDate = d;
+    changed.push('start_date');
+  }
+
+  const endDateStr = interaction.options.getString('end_date');
+  if (endDateStr) {
+    const d = new Date(endDateStr);
+    if (isNaN(d.getTime())) return interaction.editReply('❌ Invalid end date.');
+    updates.endDate = d;
+    changed.push('end_date');
+  }
+
+  const newStart = updates.startDate ?? event.startDate;
+  const newEnd = updates.endDate ?? event.endDate;
+  if (newEnd <= newStart) {
+    return interaction.editReply('❌ End date must be after start date.');
+  }
+
+  const pointsPerSubmission = interaction.options.getInteger('points_per_submission');
+  if (pointsPerSubmission !== null) {
+    updates.pointsPerSubmission = pointsPerSubmission;
+    changed.push('points_per_submission');
+  }
+
+  const maxPoints = interaction.options.getInteger('max_points');
+  if (maxPoints !== null) {
+    updates.maxPoints = maxPoints;
+    changed.push('max_points');
+  }
+
+  const creatorBonus = interaction.options.getInteger('creator_bonus');
+  if (creatorBonus !== null) {
+    updates.creatorBonus = creatorBonus;
+    changed.push('creator_bonus');
+  }
+
+  const eventPostLink = interaction.options.getString('event_post_link');
+  if (eventPostLink !== null) {
+    updates.eventPostLink = eventPostLink || null;
+    changed.push('event_post_link');
+  }
+
+  if (changed.length === 0) {
+    return interaction.editReply('ℹ️ No changes provided.');
+  }
+
+  const updated = await Event.findByIdAndUpdate(event._id, updates, { new: true });
+
+  channelLog(
+    generateSystemLogContent('Event Edited', {
+      event: `\`${updated.name}\``,
+      id: `\`${updated._id}\``,
+      changed: changed.map((f) => `\`${f}\``).join(', '),
+      editor: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  return interaction.editReply(`✅ **${updated.name}** updated. Changed: ${changed.join(', ')}`);
+}

--- a/src/service/interaction/is-chat-input-command/edit-event.js
+++ b/src/service/interaction/is-chat-input-command/edit-event.js
@@ -1,6 +1,6 @@
 import Event from '../../../models/event.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
-import { normaliseHashtag } from '../../utils/event-utils.js';
+import { findByIdOrName, normaliseHashtag } from '../../utils/event-utils.js';
 import { refreshEventCalendar } from '../../utils/event-calendar.js';
 
 /**
@@ -12,7 +12,7 @@ export default async function editEvent(interaction) {
 
   const eventName = interaction.options.getString('event_name');
 
-  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+  const event = await findByIdOrName(Event, eventName);
 
   if (!event) {
     return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
@@ -48,7 +48,7 @@ export default async function editEvent(interaction) {
   const startDateStr = interaction.options.getString('start_date');
   if (startDateStr) {
     const d = new Date(startDateStr);
-    if (isNaN(d.getTime())) return interaction.editReply('❌ Invalid start date.');
+    if (Number.isNaN(d.getTime())) return interaction.editReply('❌ Invalid start date.');
     updates.startDate = d;
     changed.push('start_date');
   }
@@ -56,7 +56,7 @@ export default async function editEvent(interaction) {
   const endDateStr = interaction.options.getString('end_date');
   if (endDateStr) {
     const d = new Date(endDateStr);
-    if (isNaN(d.getTime())) return interaction.editReply('❌ Invalid end date.');
+    if (Number.isNaN(d.getTime())) return interaction.editReply('❌ Invalid end date.');
     updates.endDate = d;
     changed.push('end_date');
   }
@@ -74,6 +74,11 @@ export default async function editEvent(interaction) {
   }
 
   const maxPoints = interaction.options.getInteger('max_points');
+  if ((pointsPerSubmission === null) !== (maxPoints === null)) {
+    return interaction.editReply(
+      '❌ `points_per_submission` and `max_points` must be provided together.',
+    );
+  }
   if (maxPoints !== null) {
     updates.maxPoints = maxPoints;
     changed.push('max_points');
@@ -97,8 +102,7 @@ export default async function editEvent(interaction) {
 
   const updated = await Event.findByIdAndUpdate(event._id, updates, { new: true });
 
-  // Refresh the calendar channel
-  refreshEventCalendar();
+  await refreshEventCalendar();
 
   channelLog(
     generateSystemLogContent('Event Edited', {

--- a/src/service/interaction/is-chat-input-command/event-calendar.js
+++ b/src/service/interaction/is-chat-input-command/event-calendar.js
@@ -1,0 +1,34 @@
+import Event from '../../../models/event.js';
+import channelLog, { generateInteractionCreateLogContent } from '../../utils/channel-log.js';
+import { buildCalendarEmbed } from '../../utils/event-utils.js';
+
+/**
+ * /calendar
+ * Displays all upcoming and active events.
+ */
+export default async function eventCalendar(interaction) {
+  await interaction.deferReply({ ephemeral: false });
+
+  channelLog(generateInteractionCreateLogContent(interaction));
+
+  const events = await Event.find({
+    status: { $in: ['pending', 'active'] },
+  }).sort({ startDate: 1 });
+
+  if (events.length === 0) {
+    return interaction.editReply('📅 No upcoming or active events right now. Check back later!');
+  }
+
+  const embeds = events.map((event) => buildCalendarEmbed(event));
+
+  // Discord allows up to 10 embeds per message
+  if (embeds.length <= 10) {
+    return interaction.editReply({ content: '## 📅 Event Calendar', embeds });
+  }
+
+  // More than 10 — send in batches
+  await interaction.editReply({ content: '## 📅 Event Calendar', embeds: embeds.slice(0, 10) });
+  for (let i = 10; i < embeds.length; i += 10) {
+    await interaction.followUp({ embeds: embeds.slice(i, i + 10) });
+  }
+}

--- a/src/service/interaction/is-chat-input-command/event-calendar.js
+++ b/src/service/interaction/is-chat-input-command/event-calendar.js
@@ -1,6 +1,40 @@
+import { EmbedBuilder } from 'discord.js';
 import Event from '../../../models/event.js';
+import LiveEvent from '../../../models/live-event.js';
 import channelLog, { generateInteractionCreateLogContent } from '../../utils/channel-log.js';
 import { buildCalendarEmbed } from '../../utils/event-utils.js';
+import {
+  computeLiveEventStatus,
+  formatScheduleSummary,
+  getNextOccurrence,
+  discordTimestamp,
+} from '../../utils/live-event-utils.js';
+
+function buildLiveEventCalendarEmbed(liveEvent) {
+  const status = computeLiveEventStatus(liveEvent);
+  const nextOccurrence = getNextOccurrence(liveEvent);
+  const hostText = liveEvent.hostIds?.length
+    ? liveEvent.hostIds.map((id) => `<@${id}>`).join(', ')
+    : 'Not specified';
+  const title = liveEvent.eventPostLink
+    ? `[🩷 ${liveEvent.name}](${liveEvent.eventPostLink})`
+    : `🩷 ${liveEvent.name}`;
+  const nextText = nextOccurrence
+    ? `${discordTimestamp(nextOccurrence.date, nextOccurrence.startTime, 'F')} → ${discordTimestamp(nextOccurrence.date, nextOccurrence.endTime, 't')}`
+    : 'No upcoming occurrence';
+
+  return new EmbedBuilder()
+    .setColor(0xed77a8)
+    .setTitle(title)
+    .addFields(
+      { name: 'Frequency', value: liveEvent.scheduleType === 'recurring' ? 'Recurring' : 'One-time', inline: true },
+      { name: 'Status', value: status, inline: true },
+      { name: 'Host(s)', value: hostText, inline: true },
+      { name: 'Location', value: `<#${liveEvent.locationChannelId}>`, inline: true },
+      { name: 'Schedule', value: formatScheduleSummary(liveEvent), inline: false },
+      { name: 'Next occurrence', value: nextText, inline: false },
+    );
+}
 
 /**
  * /calendar
@@ -15,11 +49,14 @@ export default async function eventCalendar(interaction) {
     status: { $in: ['pending', 'active'] },
   }).sort({ startDate: 1 });
 
-  if (events.length === 0) {
+  const liveEvents = await LiveEvent.find({ status: { $in: ['upcoming', 'live'] } });
+  const liveEmbeds = liveEvents.map((liveEvent) => buildLiveEventCalendarEmbed(liveEvent));
+
+  const embeds = [...events.map((event) => buildCalendarEmbed(event)), ...liveEmbeds];
+
+  if (embeds.length === 0) {
     return interaction.editReply('📅 No upcoming or active events right now. Check back later!');
   }
-
-  const embeds = events.map((event) => buildCalendarEmbed(event));
 
   // Discord allows up to 10 embeds per message
   if (embeds.length <= 10) {
@@ -31,4 +68,6 @@ export default async function eventCalendar(interaction) {
   for (let i = 10; i < embeds.length; i += 10) {
     await interaction.followUp({ embeds: embeds.slice(i, i + 10) });
   }
+
+  return undefined;
 }

--- a/src/service/interaction/is-chat-input-command/event-export.js
+++ b/src/service/interaction/is-chat-input-command/event-export.js
@@ -1,4 +1,5 @@
 import Event from '../../../models/event.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
 import EventParticipant from '../../../models/event-participant.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
 
@@ -14,7 +15,7 @@ export default async function eventExport(interaction) {
 
   const eventName = interaction.options.getString('event_name');
 
-  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+  const event = await findByIdOrName(Event, eventName);
 
   if (!event) {
     return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
@@ -77,4 +78,6 @@ export default async function eventExport(interaction) {
       requestedBy: `<@${interaction.user.id}>`,
     }),
   );
+
+  return undefined;
 }

--- a/src/service/interaction/is-chat-input-command/event-export.js
+++ b/src/service/interaction/is-chat-input-command/event-export.js
@@ -1,0 +1,80 @@
+import Event from '../../../models/event.js';
+import EventParticipant from '../../../models/event-participant.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+
+const MAX_EXPORT_CHARS = 1900; // Leave room for Discord's 2000-char limit
+
+/**
+ * /event export
+ * Generates t@scores commands for all participants.
+ * The event creator's total includes their creator bonus if configured.
+ */
+export default async function eventExport(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+
+  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+
+  if (!event) {
+    return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+  }
+
+  const participants = await EventParticipant.find({ eventId: event._id.toString() })
+    .sort({ points: -1 })
+    .lean();
+
+  if (participants.length === 0) {
+    return interaction.editReply('ℹ️ No participants to export for this event.');
+  }
+
+  if (!event.pointsPerSubmission) {
+    return interaction.editReply(
+      `❌ **${event.name}** has no points configured — nothing to export.`,
+    );
+  }
+
+  // Build one line per participant
+  const lines = participants.map((p) => {
+    let total = p.points;
+
+    // Add creator bonus only in the export total, not on the leaderboard
+    if (p.userId === event.creatorId && event.creatorBonus > 0) {
+      total += event.creatorBonus;
+    }
+
+    return `t@scores add ${p.userId} ${total}`;
+  });
+
+  // Split into chunks that fit within Discord's message limit
+  const chunks = [];
+  let current = '';
+  for (const line of lines) {
+    const candidate = current ? `${current}\n${line}` : line;
+    if (candidate.length > MAX_EXPORT_CHARS) {
+      chunks.push(current);
+      current = line;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push(current);
+
+  // Send first chunk as the deferred reply, subsequent chunks as follow-ups
+  await interaction.editReply(
+    `**Export for: ${event.name}** (${participants.length} participants)\n\`\`\`\n${chunks[0]}\n\`\`\``,
+  );
+
+  for (let i = 1; i < chunks.length; i++) {
+    await interaction.followUp({ content: `\`\`\`\n${chunks[i]}\n\`\`\``, ephemeral: true });
+  }
+
+  channelLog(
+    generateSystemLogContent('Event Export Generated', {
+      event: `\`${event.name}\``,
+      id: `\`${event._id}\``,
+      participants: `\`${participants.length}\``,
+      requestedBy: `<@${interaction.user.id}>`,
+    }),
+  );
+}

--- a/src/service/interaction/is-chat-input-command/event-info.js
+++ b/src/service/interaction/is-chat-input-command/event-info.js
@@ -1,6 +1,7 @@
 import { time } from 'discord.js';
 import Event from '../../../models/event.js';
 import EventParticipant from '../../../models/event-participant.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
 import channelLog, { generateInteractionCreateLogContent } from '../../utils/channel-log.js';
 
 /**
@@ -14,7 +15,7 @@ export default async function eventInfo(interaction) {
 
   const eventName = interaction.options.getString('event_name');
 
-  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+  const event = await findByIdOrName(Event, eventName);
 
   if (!event) {
     return interaction.editReply(`❌ No event found with the name **${eventName}**.`);

--- a/src/service/interaction/is-chat-input-command/event-info.js
+++ b/src/service/interaction/is-chat-input-command/event-info.js
@@ -1,0 +1,78 @@
+import { time } from 'discord.js';
+import Event from '../../../models/event.js';
+import EventParticipant from '../../../models/event-participant.js';
+import channelLog, { generateInteractionCreateLogContent } from '../../utils/channel-log.js';
+
+/**
+ * /event info
+ * Looks up an event by name (case-insensitive) and displays its full config and status.
+ */
+export default async function eventInfo(interaction) {
+  await interaction.deferReply({ ephemeral: false });
+
+  channelLog(generateInteractionCreateLogContent(interaction));
+
+  const eventName = interaction.options.getString('event_name');
+
+  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+
+  if (!event) {
+    return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+  }
+
+  const participantCount = await EventParticipant.countDocuments({
+    eventId: event._id.toString(),
+  });
+
+  const statusLabel =
+    event.status === 'active' ? '🟢 Active' : event.status === 'ended' ? '⚫ Ended' : '🕐 Upcoming';
+
+  const fields = [
+    { name: 'Type', value: event.eventType, inline: true },
+    { name: 'Status', value: statusLabel, inline: true },
+    { name: 'Creator', value: `<@${event.creatorId}>`, inline: true },
+    { name: 'Hashtag', value: `\`${event.hashtag}\``, inline: true },
+    { name: 'Submission Channel', value: `<#${event.submissionChannelId}>`, inline: true },
+    { name: 'Participants', value: `${participantCount}`, inline: true },
+    {
+      name: 'Start',
+      value: time(Math.floor(event.startDate.getTime() / 1000), 'F'),
+      inline: true,
+    },
+    {
+      name: 'End',
+      value: time(Math.floor(event.endDate.getTime() / 1000), 'F'),
+      inline: true,
+    },
+  ];
+
+  if (event.pointsPerSubmission) {
+    fields.push(
+      { name: 'Points per Submission', value: `${event.pointsPerSubmission}`, inline: true },
+      { name: 'Max Points', value: `${event.maxPoints}`, inline: true },
+      {
+        name: 'Creator Bonus',
+        value: event.creatorBonus > 0 ? `${event.creatorBonus}` : '*(none)*',
+        inline: true,
+      },
+    );
+  } else {
+    fields.push({ name: 'Points', value: 'Tracking only (no points)', inline: true });
+  }
+
+  if (event.eventPostLink) {
+    fields.push({ name: 'Event Post', value: event.eventPostLink, inline: false });
+  }
+
+  return interaction.editReply({
+    embeds: [
+      {
+        color: 0x4a90d9,
+        title: event.name,
+        fields,
+        footer: { text: `Event ID: ${event._id}` },
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+}

--- a/src/service/interaction/is-chat-input-command/event-leaderboard.js
+++ b/src/service/interaction/is-chat-input-command/event-leaderboard.js
@@ -1,0 +1,95 @@
+import Event from '../../../models/event.js';
+import EventLeaderboard from '../../../models/event-leaderboard.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { buildLiveLeaderboardEmbed } from '../../utils/event-utils.js';
+import client from '../../../client/index.js';
+
+/**
+ * /event leaderboard
+ * Posts the live leaderboard embed in the event's submission channel, pins it,
+ * and stores the message ID so the submission handler can edit it on every new submission.
+ *
+ * If a leaderboard record already exists but the message has been deleted,
+ * it replaces the record with a fresh post automatically.
+ *
+ * Events without points configured do not get a leaderboard.
+ */
+export default async function eventLeaderboard(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+
+  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+
+  if (!event) {
+    return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+  }
+
+  if (!event.pointsPerSubmission) {
+    return interaction.editReply(
+      `❌ **${event.name}** has no points configured — leaderboards are only available for point-based events.`,
+    );
+  }
+
+  // Fetch the submission channel from the event itself
+  let channel;
+  try {
+    channel = await client.channels.fetch(event.submissionChannelId);
+  } catch {
+    return interaction.editReply(
+      `❌ Could not fetch the submission channel <#${event.submissionChannelId}>. Check bot permissions.`,
+    );
+  }
+
+  if (!channel) {
+    return interaction.editReply(`❌ Submission channel not found.`);
+  }
+
+  const existing = await EventLeaderboard.findOne({ eventId: event._id.toString() });
+
+  if (existing) {
+    // Check if the stored message still exists
+    let messageStillExists = false;
+    try {
+      await channel.messages.fetch(existing.messageId);
+      messageStillExists = true;
+    } catch {
+      // Message was deleted — we'll replace the record
+    }
+
+    if (messageStillExists) {
+      return interaction.editReply(
+        `❌ A leaderboard for **${event.name}** already exists in <#${existing.channelId}>.\n` +
+          `https://discord.com/channels/${interaction.guildId}/${existing.channelId}/${existing.messageId}`,
+      );
+    }
+
+    // Message gone — delete the stale record and re-post
+    await EventLeaderboard.deleteOne({ eventId: event._id.toString() });
+  }
+
+  const embed = await buildLiveLeaderboardEmbed(event);
+  const posted = await channel.send({ embeds: [embed] });
+
+  try {
+    await posted.pin();
+  } catch {
+    // Missing pin permissions — not fatal
+  }
+
+  await EventLeaderboard.create({
+    eventId: event._id.toString(),
+    channelId: channel.id,
+    messageId: posted.id,
+  });
+
+  channelLog(
+    generateSystemLogContent('Event Leaderboard Posted', {
+      event: `\`${event.name}\``,
+      channel: `<#${channel.id}>`,
+      postedBy: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  return interaction.editReply(`✅ Leaderboard posted and pinned in <#${channel.id}>.`);
+}

--- a/src/service/interaction/is-chat-input-command/event-leaderboard.js
+++ b/src/service/interaction/is-chat-input-command/event-leaderboard.js
@@ -1,7 +1,7 @@
 import Event from '../../../models/event.js';
 import EventLeaderboard from '../../../models/event-leaderboard.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
-import { buildLiveLeaderboardEmbed } from '../../utils/event-utils.js';
+import { buildLiveLeaderboardEmbed, findByIdOrName } from '../../utils/event-utils.js';
 import client from '../../../client/index.js';
 
 /**
@@ -19,7 +19,7 @@ export default async function eventLeaderboard(interaction) {
 
   const eventName = interaction.options.getString('event_name');
 
-  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+  const event = await findByIdOrName(Event, eventName);
 
   if (!event) {
     return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
@@ -42,7 +42,7 @@ export default async function eventLeaderboard(interaction) {
   }
 
   if (!channel) {
-    return interaction.editReply(`❌ Submission channel not found.`);
+    return interaction.editReply('❌ Submission channel not found.');
   }
 
   const existing = await EventLeaderboard.findOne({ eventId: event._id.toString() });

--- a/src/service/interaction/is-chat-input-command/event-participant.js
+++ b/src/service/interaction/is-chat-input-command/event-participant.js
@@ -3,10 +3,11 @@ import EventParticipant from '../../../models/event-participant.js';
 import EventSubmission from '../../../models/event-submission.js';
 import EventBan from '../../../models/event-ban.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
-import { updateLiveLeaderboard } from '../../utils/event-utils.js';
+import { findByIdOrName, updateLiveLeaderboard } from '../../utils/event-utils.js';
+import { hasManageEventsPermission } from '../../utils/permissions.js';
 
 async function findEventByName(name) {
-  return Event.findOne({ name: { $regex: new RegExp(`^${name}$`, 'i') } });
+  return findByIdOrName(Event, name);
 }
 
 /**
@@ -16,6 +17,10 @@ async function findEventByName(name) {
  */
 export async function eventParticipantRemove(interaction) {
   await interaction.deferReply({ ephemeral: true });
+
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply('❌ You need the Manage Events permission to ban participants.');
+  }
 
   const eventName = interaction.options.getString('event_name');
   const targetUser = interaction.options.getUser('user');
@@ -99,6 +104,6 @@ export async function eventParticipantBan(interaction) {
 
   return interaction.editReply(
     `✅ <@${targetUser.id}> has been banned from earning points in **${event.name}**.\n` +
-      `Their existing points are unchanged. Use \`/event points remove\` to deduct them if needed.`,
+      'Their existing points are unchanged. Use `/event points remove` to deduct them if needed.',
   );
 }

--- a/src/service/interaction/is-chat-input-command/event-participant.js
+++ b/src/service/interaction/is-chat-input-command/event-participant.js
@@ -1,0 +1,104 @@
+import Event from '../../../models/event.js';
+import EventParticipant from '../../../models/event-participant.js';
+import EventSubmission from '../../../models/event-submission.js';
+import EventBan from '../../../models/event-ban.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { updateLiveLeaderboard } from '../../utils/event-utils.js';
+
+async function findEventByName(name) {
+  return Event.findOne({ name: { $regex: new RegExp(`^${name}$`, 'i') } });
+}
+
+/**
+ * /event participant remove
+ * Removes a participant and all their tracked event data.
+ * Does not ban them — they can still earn points again if they resubmit.
+ */
+export async function eventParticipantRemove(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+  const targetUser = interaction.options.getUser('user');
+
+  const event = await findEventByName(eventName);
+  if (!event) return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+
+  const participant = await EventParticipant.findOne({
+    eventId: event._id.toString(),
+    userId: targetUser.id,
+  });
+
+  if (!participant) {
+    return interaction.editReply(
+      `ℹ️ <@${targetUser.id}> is not a recorded participant for this event.`,
+    );
+  }
+
+  await Promise.all([
+    EventParticipant.deleteOne({ eventId: event._id.toString(), userId: targetUser.id }),
+    EventSubmission.deleteMany({ eventId: event._id.toString(), userId: targetUser.id }),
+  ]);
+
+  channelLog(
+    generateSystemLogContent('Event Participant Removed', {
+      event: `\`${event.name}\``,
+      user: `<@${targetUser.id}>`,
+      pointsRemoved: `\`${participant.points}\``,
+      moderator: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  // Refresh the leaderboard since rankings may have changed
+  await updateLiveLeaderboard(event);
+
+  return interaction.editReply(
+    `✅ <@${targetUser.id}>'s data for **${event.name}** has been removed.\n` +
+      `(${participant.points} points, ${participant.submissionCount} submissions deleted)`,
+  );
+}
+
+/**
+ * /event participant ban
+ * Prevents a participant from earning further points for an event.
+ * Existing points are NOT removed unless a moderator separately uses /event points remove.
+ */
+export async function eventParticipantBan(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+  const targetUser = interaction.options.getUser('user');
+
+  const event = await findEventByName(eventName);
+  if (!event) return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+
+  const existingBan = await EventBan.findOne({
+    eventId: event._id.toString(),
+    userId: targetUser.id,
+  });
+
+  if (existingBan) {
+    return interaction.editReply(
+      `ℹ️ <@${targetUser.id}> is already banned from **${event.name}**.`,
+    );
+  }
+
+  const ban = new EventBan({
+    eventId: event._id.toString(),
+    userId: targetUser.id,
+    bannedBy: interaction.user.id,
+  });
+  await ban.save();
+
+  channelLog(
+    generateSystemLogContent('Event Participant Banned', {
+      event: `\`${event.name}\``,
+      user: `<@${targetUser.id}>`,
+      moderator: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  return interaction.editReply(
+    `✅ <@${targetUser.id}> has been banned from earning points in **${event.name}**.\n` +
+      `Their existing points are unchanged. Use \`/event points remove\` to deduct them if needed.`,
+  );
+}

--- a/src/service/interaction/is-chat-input-command/event-points.js
+++ b/src/service/interaction/is-chat-input-command/event-points.js
@@ -1,10 +1,15 @@
 import Event from '../../../models/event.js';
 import EventParticipant from '../../../models/event-participant.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
-import { updateLiveLeaderboard } from '../../utils/event-utils.js';
+import {
+  findByIdOrName,
+  incrementParticipantTotals,
+  updateLiveLeaderboard,
+} from '../../utils/event-utils.js';
+import { hasManageEventsPermission } from '../../utils/permissions.js';
 
 async function findEventByName(name) {
-  return Event.findOne({ name: { $regex: new RegExp(`^${name}$`, 'i') } });
+  return findByIdOrName(Event, name);
 }
 
 /**
@@ -13,6 +18,10 @@ async function findEventByName(name) {
  */
 export async function eventPointsAdd(interaction) {
   await interaction.deferReply({ ephemeral: true });
+
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply('❌ You need the Manage Events permission to change points.');
+  }
 
   const eventName = interaction.options.getString('event_name');
   const targetUser = interaction.options.getUser('user');
@@ -25,31 +34,25 @@ export async function eventPointsAdd(interaction) {
     return interaction.editReply(`❌ **${event.name}** has no points configured.`);
   }
 
-  let participant = await EventParticipant.findOne({
+  const participant = await EventParticipant.findOne({
     eventId: event._id.toString(),
     userId: targetUser.id,
   });
 
-  if (!participant) {
-    participant = new EventParticipant({
-      eventId: event._id.toString(),
-      userId: targetUser.id,
-      points: 0,
-      submissionCount: 0,
-    });
-  }
-
-  const before = participant.points;
-  participant.points = Math.min(participant.points + amount, event.maxPoints);
-  const actual = participant.points - before;
-  await participant.save();
+  const before = participant?.points ?? 0;
+  const actual = Math.min(amount, Math.max(0, event.maxPoints - before));
+  const updatedParticipant = await incrementParticipantTotals({
+    eventId: event._id.toString(),
+    userId: targetUser.id,
+    points: actual,
+  });
 
   channelLog(
     generateSystemLogContent('Event Points Added (Manual)', {
       event: `\`${event.name}\``,
       user: `<@${targetUser.id}>`,
       added: `\`+${actual}\``,
-      total: `\`${participant.points}/${event.maxPoints}\``,
+      total: `\`${updatedParticipant.points}/${event.maxPoints}\``,
       moderator: `<@${interaction.user.id}>`,
     }),
   );
@@ -58,7 +61,7 @@ export async function eventPointsAdd(interaction) {
 
   return interaction.editReply(
     `✅ Added **${actual}** points to <@${targetUser.id}> for **${event.name}**.\n` +
-      `New total: **${participant.points}** / ${event.maxPoints}`,
+      `New total: **${updatedParticipant.points}** / ${event.maxPoints}`,
   );
 }
 
@@ -68,6 +71,10 @@ export async function eventPointsAdd(interaction) {
  */
 export async function eventPointsRemove(interaction) {
   await interaction.deferReply({ ephemeral: true });
+
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply('❌ You need the Manage Events permission to change points.');
+  }
 
   const eventName = interaction.options.getString('event_name');
   const targetUser = interaction.options.getUser('user');
@@ -90,16 +97,19 @@ export async function eventPointsRemove(interaction) {
   }
 
   const before = participant.points;
-  participant.points = Math.max(0, participant.points - amount);
-  const actual = before - participant.points;
-  await participant.save();
+  const actual = Math.min(amount, before);
+  const updatedParticipant = await EventParticipant.findOneAndUpdate(
+    { eventId: event._id.toString(), userId: targetUser.id },
+    { $inc: { points: -actual } },
+    { new: true },
+  );
 
   channelLog(
     generateSystemLogContent('Event Points Removed (Manual)', {
       event: `\`${event.name}\``,
       user: `<@${targetUser.id}>`,
       removed: `\`-${actual}\``,
-      total: `\`${participant.points}/${event.maxPoints}\``,
+      total: `\`${updatedParticipant.points}/${event.maxPoints}\``,
       moderator: `<@${interaction.user.id}>`,
     }),
   );
@@ -108,6 +118,6 @@ export async function eventPointsRemove(interaction) {
 
   return interaction.editReply(
     `✅ Removed **${actual}** points from <@${targetUser.id}> for **${event.name}**.\n` +
-      `New total: **${participant.points}** / ${event.maxPoints}`,
+      `New total: **${updatedParticipant.points}** / ${event.maxPoints}`,
   );
 }

--- a/src/service/interaction/is-chat-input-command/event-points.js
+++ b/src/service/interaction/is-chat-input-command/event-points.js
@@ -1,0 +1,113 @@
+import Event from '../../../models/event.js';
+import EventParticipant from '../../../models/event-participant.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { updateLiveLeaderboard } from '../../utils/event-utils.js';
+
+async function findEventByName(name) {
+  return Event.findOne({ name: { $regex: new RegExp(`^${name}$`, 'i') } });
+}
+
+/**
+ * /event points add
+ * Manually adds points to a participant. Capped at maxPoints.
+ */
+export async function eventPointsAdd(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+  const targetUser = interaction.options.getUser('user');
+  const amount = interaction.options.getInteger('amount');
+
+  const event = await findEventByName(eventName);
+  if (!event) return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+
+  if (!event.pointsPerSubmission) {
+    return interaction.editReply(`❌ **${event.name}** has no points configured.`);
+  }
+
+  let participant = await EventParticipant.findOne({
+    eventId: event._id.toString(),
+    userId: targetUser.id,
+  });
+
+  if (!participant) {
+    participant = new EventParticipant({
+      eventId: event._id.toString(),
+      userId: targetUser.id,
+      points: 0,
+      submissionCount: 0,
+    });
+  }
+
+  const before = participant.points;
+  participant.points = Math.min(participant.points + amount, event.maxPoints);
+  const actual = participant.points - before;
+  await participant.save();
+
+  channelLog(
+    generateSystemLogContent('Event Points Added (Manual)', {
+      event: `\`${event.name}\``,
+      user: `<@${targetUser.id}>`,
+      added: `\`+${actual}\``,
+      total: `\`${participant.points}/${event.maxPoints}\``,
+      moderator: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  await updateLiveLeaderboard(event);
+
+  return interaction.editReply(
+    `✅ Added **${actual}** points to <@${targetUser.id}> for **${event.name}**.\n` +
+      `New total: **${participant.points}** / ${event.maxPoints}`,
+  );
+}
+
+/**
+ * /event points remove
+ * Manually removes points from a participant. Floors at 0.
+ */
+export async function eventPointsRemove(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+  const targetUser = interaction.options.getUser('user');
+  const amount = interaction.options.getInteger('amount');
+
+  const event = await findEventByName(eventName);
+  if (!event) return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+
+  if (!event.pointsPerSubmission) {
+    return interaction.editReply(`❌ **${event.name}** has no points configured.`);
+  }
+
+  const participant = await EventParticipant.findOne({
+    eventId: event._id.toString(),
+    userId: targetUser.id,
+  });
+
+  if (!participant) {
+    return interaction.editReply(`ℹ️ <@${targetUser.id}> has no recorded points for this event.`);
+  }
+
+  const before = participant.points;
+  participant.points = Math.max(0, participant.points - amount);
+  const actual = before - participant.points;
+  await participant.save();
+
+  channelLog(
+    generateSystemLogContent('Event Points Removed (Manual)', {
+      event: `\`${event.name}\``,
+      user: `<@${targetUser.id}>`,
+      removed: `\`-${actual}\``,
+      total: `\`${participant.points}/${event.maxPoints}\``,
+      moderator: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  await updateLiveLeaderboard(event);
+
+  return interaction.editReply(
+    `✅ Removed **${actual}** points from <@${targetUser.id}> for **${event.name}**.\n` +
+      `New total: **${participant.points}** / ${event.maxPoints}`,
+  );
+}

--- a/src/service/interaction/is-chat-input-command/event-remove.js
+++ b/src/service/interaction/is-chat-input-command/event-remove.js
@@ -5,6 +5,7 @@ import EventSubmission from '../../../models/event-submission.js';
 import EventBan from '../../../models/event-ban.js';
 import EventLeaderboard from '../../../models/event-leaderboard.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
 
 /**
  * /event remove
@@ -83,6 +84,9 @@ export async function handleEventRemoveConfirm(interaction) {
       removedBy: `<@${interaction.user.id}>`,
     }),
   );
+
+  // Refresh the calendar channel
+  refreshEventCalendar();
 
   return interaction.editReply({
     content: `🗑️ Event **${event.name}** and all associated data have been permanently deleted.`,

--- a/src/service/interaction/is-chat-input-command/event-remove.js
+++ b/src/service/interaction/is-chat-input-command/event-remove.js
@@ -6,27 +6,31 @@ import EventBan from '../../../models/event-ban.js';
 import EventLeaderboard from '../../../models/event-leaderboard.js';
 import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
 import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+import { hasManageEventsPermission } from '../../utils/permissions.js';
 
 /**
  * /event remove
  * Shows a confirmation prompt before permanently deleting an event and all its data.
- * The actual deletion is handled by handleEventRemoveConfirm() below, triggered
- * by the confirm button in interaction-create.js.
  */
 export default async function eventRemove(interaction) {
   await interaction.deferReply({ ephemeral: true });
 
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply('❌ You need the Manage Events permission to remove events.');
+  }
+
   const eventName = interaction.options.getString('event_name');
 
-  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+  const event = await findByIdOrName(Event, eventName);
 
   if (!event) {
     return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
   }
 
-  const participantCount = await EventParticipant.countDocuments({
-    eventId: event._id.toString(),
-  });
+  const eventId = event._id.toString();
+
+  const participantCount = await EventParticipant.countDocuments({ eventId });
 
   const confirmRow = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
@@ -43,17 +47,23 @@ export default async function eventRemove(interaction) {
     content:
       `⚠️ **Permanently delete "${event.name}"?**\n` +
       `This will remove the event and data for **${participantCount} participant(s)**.\n` +
-      `This action **cannot be undone**.`,
+      'This action **cannot be undone**.',
     components: [confirmRow],
   });
 }
 
 /**
  * Handles the confirm button press for event removal.
- * Called from interaction-create.js when customId starts with `event-remove-confirm:`.
  */
 export async function handleEventRemoveConfirm(interaction) {
   await interaction.deferUpdate();
+
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply({
+      content: '❌ You need the Manage Events permission to remove events.',
+      components: [],
+    });
+  }
 
   const eventId = interaction.customId.split(':')[1];
 
@@ -68,7 +78,6 @@ export async function handleEventRemoveConfirm(interaction) {
     return interaction.editReply({ content: '❌ Event not found.', components: [] });
   }
 
-  // Delete all associated data
   await Promise.all([
     EventParticipant.deleteMany({ eventId }),
     EventSubmission.deleteMany({ eventId }),
@@ -85,8 +94,7 @@ export async function handleEventRemoveConfirm(interaction) {
     }),
   );
 
-  // Refresh the calendar channel
-  refreshEventCalendar();
+  await refreshEventCalendar();
 
   return interaction.editReply({
     content: `🗑️ Event **${event.name}** and all associated data have been permanently deleted.`,

--- a/src/service/interaction/is-chat-input-command/event-remove.js
+++ b/src/service/interaction/is-chat-input-command/event-remove.js
@@ -1,0 +1,99 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import Event from '../../../models/event.js';
+import EventParticipant from '../../../models/event-participant.js';
+import EventSubmission from '../../../models/event-submission.js';
+import EventBan from '../../../models/event-ban.js';
+import EventLeaderboard from '../../../models/event-leaderboard.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+
+/**
+ * /event remove
+ * Shows a confirmation prompt before permanently deleting an event and all its data.
+ * The actual deletion is handled by handleEventRemoveConfirm() below, triggered
+ * by the confirm button in interaction-create.js.
+ */
+export default async function eventRemove(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+
+  const event = await Event.findOne({ name: { $regex: new RegExp(`^${eventName}$`, 'i') } });
+
+  if (!event) {
+    return interaction.editReply(`❌ No event found with the name **${eventName}**.`);
+  }
+
+  const participantCount = await EventParticipant.countDocuments({
+    eventId: event._id.toString(),
+  });
+
+  const confirmRow = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`event-remove-confirm:${eventId}`)
+      .setLabel('Yes, delete permanently')
+      .setStyle(ButtonStyle.Danger),
+    new ButtonBuilder()
+      .setCustomId(`event-remove-cancel:${eventId}`)
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return interaction.editReply({
+    content:
+      `⚠️ **Permanently delete "${event.name}"?**\n` +
+      `This will remove the event and data for **${participantCount} participant(s)**.\n` +
+      `This action **cannot be undone**.`,
+    components: [confirmRow],
+  });
+}
+
+/**
+ * Handles the confirm button press for event removal.
+ * Called from interaction-create.js when customId starts with `event-remove-confirm:`.
+ */
+export async function handleEventRemoveConfirm(interaction) {
+  await interaction.deferUpdate();
+
+  const eventId = interaction.customId.split(':')[1];
+
+  let event;
+  try {
+    event = await Event.findById(eventId);
+  } catch {
+    return interaction.editReply({ content: '❌ Invalid event ID.', components: [] });
+  }
+
+  if (!event) {
+    return interaction.editReply({ content: '❌ Event not found.', components: [] });
+  }
+
+  // Delete all associated data
+  await Promise.all([
+    EventParticipant.deleteMany({ eventId }),
+    EventSubmission.deleteMany({ eventId }),
+    EventBan.deleteMany({ eventId }),
+    EventLeaderboard.deleteOne({ eventId }),
+    Event.findByIdAndDelete(eventId),
+  ]);
+
+  channelLog(
+    generateSystemLogContent('Event Removed', {
+      event: `\`${event.name}\``,
+      id: `\`${eventId}\``,
+      removedBy: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  return interaction.editReply({
+    content: `🗑️ Event **${event.name}** and all associated data have been permanently deleted.`,
+    components: [],
+  });
+}
+
+/**
+ * Handles the cancel button press for event removal.
+ */
+export async function handleEventRemoveCancel(interaction) {
+  await interaction.deferUpdate();
+  return interaction.editReply({ content: '✅ Event removal cancelled.', components: [] });
+}

--- a/src/service/interaction/is-chat-input-command/live-event-create.js
+++ b/src/service/interaction/is-chat-input-command/live-event-create.js
@@ -1,0 +1,203 @@
+import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import {
+  computeLiveEventStatus,
+  parseOneTimeScheduleInput,
+  parseRecurringScheduleInput,
+} from '../../utils/live-event-utils.js';
+
+/**
+ * /live-event create
+ *
+ * Slash command collects: name, location (channel picker), schedule_type, up to 3 hosts.
+ * A modal then collects: schedule dates/times, and optional event post link.
+ *
+ * The customId carries: name, locationChannelId, scheduleType, hostIds (comma-separated).
+ * Event post link goes in the modal so URLs don't blow the 100-char customId limit.
+ */
+export default async function liveEventCreate(interaction) {
+  const name = interaction.options.getString('name');
+  const locationChannel = interaction.options.getChannel('location');
+  const scheduleType = interaction.options.getString('schedule_type');
+  const host1 = interaction.options.getUser('host');
+  const host2 = interaction.options.getUser('host_2');
+  const host3 = interaction.options.getUser('host_3');
+
+  const hostIds = [host1, host2, host3].filter(Boolean).map((u) => u.id);
+
+  // Keep customId short: encode only what can't go in the modal
+  const payload = [
+    encodeURIComponent(name),
+    locationChannel.id,
+    scheduleType,
+    hostIds.join(','),
+  ].join('\x01');
+
+  const customId = `live-event-create-modal\x00${payload}`;
+
+  const modal = new ModalBuilder()
+    .setCustomId(customId)
+    .setTitle(
+      scheduleType === 'one-time'
+        ? 'Create Live Event — Date & Time'
+        : 'Create Live Event — Schedule',
+    );
+
+  // Field 1: event post link (optional) — in modal so URLs don't hit customId limit
+  const postLinkInput = new TextInputBuilder()
+    .setCustomId('event_post_link')
+    .setLabel('Event post link (optional)')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('https://discord.com/channels/...')
+    .setRequired(false)
+    .setMaxLength(500);
+
+  if (scheduleType === 'one-time') {
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(postLinkInput),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('date')
+          .setLabel('Date in UTC (YYYY-MM-DD)')
+          .setStyle(TextInputStyle.Short)
+          .setPlaceholder('2026-08-28')
+          .setRequired(true)
+          .setMaxLength(10),
+      ),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('start_time')
+          .setLabel('Start time in UTC (HH:MM)')
+          .setStyle(TextInputStyle.Short)
+          .setPlaceholder('18:00')
+          .setRequired(true)
+          .setMaxLength(5),
+      ),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('end_time')
+          .setLabel('End time in UTC (HH:MM)')
+          .setStyle(TextInputStyle.Short)
+          .setPlaceholder('19:00')
+          .setRequired(true)
+          .setMaxLength(5),
+      ),
+    );
+  } else {
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(postLinkInput),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('recurrence_range')
+          .setLabel('Recurrence range (YYYY-MM-DD to YYYY-MM-DD)')
+          .setStyle(TextInputStyle.Short)
+          .setPlaceholder('2026-08-01 to 2026-12-31')
+          .setRequired(true)
+          .setMaxLength(25),
+      ),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('slots')
+          .setLabel('Weekly slots — one per line (Day HH:MM-HH:MM)')
+          .setStyle(TextInputStyle.Paragraph)
+          .setPlaceholder('Tuesday 18:00-19:00\nSaturday 10:00-11:00')
+          .setRequired(true)
+          .setMaxLength(500),
+      ),
+    );
+  }
+
+  await interaction.showModal(modal);
+}
+
+// ─── Modal submit ─────────────────────────────────────────────────────────────
+
+export async function handleLiveEventCreateModalSubmit(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const [, payload] = interaction.customId.split('\x00');
+  const [encodedName, locationChannelId, scheduleType, hostIdsStr] = payload.split('\x01');
+
+  const name = decodeURIComponent(encodedName);
+  const hostIds = hostIdsStr ? hostIdsStr.split(',').filter(Boolean) : [];
+  const eventPostLink = interaction.fields.getTextInputValue('event_post_link').trim() || null;
+
+  let scheduleData;
+
+  if (scheduleType === 'one-time') {
+    const date = interaction.fields.getTextInputValue('date').trim();
+    const startTime = interaction.fields.getTextInputValue('start_time').trim();
+    const endTime = interaction.fields.getTextInputValue('end_time').trim();
+
+    const result = parseOneTimeScheduleInput(date, `${startTime}-${endTime}`);
+    if (result.error) return interaction.editReply(`❌ ${result.error}`);
+    scheduleData = result;
+  } else {
+    const recurrenceRaw = interaction.fields.getTextInputValue('recurrence_range').trim();
+    const slotsRaw = interaction.fields.getTextInputValue('slots').trim();
+
+    const result = parseRecurringScheduleInput(recurrenceRaw, slotsRaw);
+    if (result.error) return interaction.editReply(`❌ ${result.error}`);
+    scheduleData = result;
+  }
+
+  const doc = {
+    name,
+    locationChannelId,
+    hostIds,
+    eventPostLink,
+    scheduleType,
+    creatorId: interaction.user.id,
+  };
+
+  if (scheduleType === 'one-time') {
+    doc.oneTimeDate = scheduleData.date;
+    doc.oneTimeStartTime = scheduleData.startTime;
+    doc.oneTimeEndTime = scheduleData.endTime;
+  } else {
+    doc.recurrenceStartDate = scheduleData.recurrenceStartDate;
+    doc.recurrenceEndDate = scheduleData.recurrenceEndDate;
+    doc.slots = scheduleData.slots;
+  }
+
+  const liveEvent = new LiveEvent(doc);
+  liveEvent.status = computeLiveEventStatus(liveEvent);
+  await liveEvent.save();
+
+  await refreshEventCalendar();
+
+  channelLog(
+    generateSystemLogContent('Live Event Created', {
+      event: `\`${name}\``,
+      id: `\`${liveEvent._id}\``,
+      scheduleType: `\`${scheduleType}\``,
+      location: `<#${locationChannelId}>`,
+      hosts: hostIds.length ? hostIds.map((id) => `<@${id}>`).join(', ') : '*(none)*',
+      creator: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  const DAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const scheduleLines =
+    scheduleType === 'one-time'
+      ? `📅 ${scheduleData.date} · ${scheduleData.startTime}–${scheduleData.endTime} UTC`
+      : [
+          `📅 ${scheduleData.recurrenceStartDate} → ${scheduleData.recurrenceEndDate}`,
+          ...scheduleData.slots.map(
+            (s) => `  • ${DAY_ABBR[s.dayOfWeek]} ${s.startTime}–${s.endTime} UTC`,
+          ),
+        ].join('\n');
+
+  const hostLine = hostIds.length
+    ? `**Host(s):** ${hostIds.map((id) => `<@${id}>`).join(', ')}\n`
+    : '';
+
+  return interaction.editReply(
+    `✅ Live Event **${name}** created (ID: \`${liveEvent._id}\`).\n` +
+      hostLine +
+      `**Location:** <#${locationChannelId}>\n` +
+      scheduleLines,
+  );
+}

--- a/src/service/interaction/is-chat-input-command/live-event-edit.js
+++ b/src/service/interaction/is-chat-input-command/live-event-edit.js
@@ -1,0 +1,172 @@
+import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import {
+  computeLiveEventStatus,
+  parseOneTimeScheduleInput,
+  parseRecurringScheduleInput,
+} from '../../utils/live-event-utils.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+
+/**
+ * /live-event edit
+ *
+ * Non-schedule fields (name, location, hosts, event_post_link) are applied directly
+ * from slash options before the modal opens.
+ * Schedule fields are collected via a pre-filled modal.
+ *
+ * customId carries: eventId only (applied changes tracked in DB before modal shown)
+ */
+export default async function liveEventEdit(interaction) {
+  const eventName = interaction.options.getString('event_name');
+
+  const liveEvent = await findByIdOrName(LiveEvent, eventName);
+
+  if (!liveEvent) {
+    await interaction.deferReply({ ephemeral: true });
+    return interaction.editReply(`❌ No live event found with the name **${eventName}**.`);
+  }
+
+  // Apply simple field changes immediately before showing modal
+  const newName = interaction.options.getString('name');
+  const newLocationChannel = interaction.options.getChannel('location');
+  const host1 = interaction.options.getUser('host');
+  const host2 = interaction.options.getUser('host_2');
+  const host3 = interaction.options.getUser('host_3');
+  const newHostIds = [host1, host2, host3].filter(Boolean).map((u) => u.id);
+  // getString returns null if not provided, empty string if provided but blank
+  const postLinkOption = interaction.options.getString('event_post_link');
+
+  if (newName) liveEvent.name = newName;
+  if (newLocationChannel) liveEvent.locationChannelId = newLocationChannel.id;
+  if (newHostIds.length > 0) liveEvent.hostIds = newHostIds;
+  if (postLinkOption !== null) liveEvent.eventPostLink = postLinkOption || null;
+
+  await liveEvent.save();
+
+  // Now show the modal for schedule editing
+  const customId = `live-event-edit-modal\x00${liveEvent._id.toString()}`;
+
+  const modal = new ModalBuilder().setCustomId(customId).setTitle('Edit Live Event — Schedule');
+
+  const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+  if (liveEvent.scheduleType === 'one-time') {
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('date')
+          .setLabel('Date in UTC (YYYY-MM-DD)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(liveEvent.oneTimeDate ?? '')
+          .setRequired(true)
+          .setMaxLength(10),
+      ),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('start_time')
+          .setLabel('Start time in UTC (HH:MM)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(liveEvent.oneTimeStartTime ?? '')
+          .setRequired(true)
+          .setMaxLength(5),
+      ),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('end_time')
+          .setLabel('End time in UTC (HH:MM)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(liveEvent.oneTimeEndTime ?? '')
+          .setRequired(true)
+          .setMaxLength(5),
+      ),
+    );
+  } else {
+    const currentRange =
+      liveEvent.recurrenceStartDate && liveEvent.recurrenceEndDate
+        ? `${liveEvent.recurrenceStartDate} to ${liveEvent.recurrenceEndDate}`
+        : '';
+    const currentSlots = (liveEvent.slots ?? [])
+      .map((s) => `${DAY_NAMES[s.dayOfWeek]} ${s.startTime}-${s.endTime}`)
+      .join('\n');
+
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('recurrence_range')
+          .setLabel('Recurrence range (YYYY-MM-DD to YYYY-MM-DD)')
+          .setStyle(TextInputStyle.Short)
+          .setValue(currentRange)
+          .setRequired(true)
+          .setMaxLength(25),
+      ),
+      new ActionRowBuilder().addComponents(
+        new TextInputBuilder()
+          .setCustomId('slots')
+          .setLabel('Weekly slots — one per line (Day HH:MM-HH:MM)')
+          .setStyle(TextInputStyle.Paragraph)
+          .setValue(currentSlots)
+          .setRequired(true)
+          .setMaxLength(500),
+      ),
+    );
+  }
+
+  return interaction.showModal(modal);
+}
+
+// ─── Modal submit ─────────────────────────────────────────────────────────────
+
+export async function handleLiveEventEditModalSubmit(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const [, eventId] = interaction.customId.split('\x00');
+
+  let liveEvent;
+  try {
+    liveEvent = await LiveEvent.findById(eventId);
+  } catch {
+    return interaction.editReply('❌ Invalid event ID.');
+  }
+  if (!liveEvent) return interaction.editReply('❌ Live event not found.');
+
+  // Apply schedule changes from modal
+  if (liveEvent.scheduleType === 'one-time') {
+    const date = interaction.fields.getTextInputValue('date').trim();
+    const startTime = interaction.fields.getTextInputValue('start_time').trim();
+    const endTime = interaction.fields.getTextInputValue('end_time').trim();
+
+    const result = parseOneTimeScheduleInput(date, `${startTime}-${endTime}`);
+    if (result.error) return interaction.editReply(`❌ ${result.error}`);
+
+    liveEvent.oneTimeDate = result.date;
+    liveEvent.oneTimeStartTime = result.startTime;
+    liveEvent.oneTimeEndTime = result.endTime;
+  } else {
+    const recurrenceRaw = interaction.fields.getTextInputValue('recurrence_range').trim();
+    const slotsRaw = interaction.fields.getTextInputValue('slots').trim();
+
+    const result = parseRecurringScheduleInput(recurrenceRaw, slotsRaw);
+    if (result.error) return interaction.editReply(`❌ ${result.error}`);
+
+    liveEvent.recurrenceStartDate = result.recurrenceStartDate;
+    liveEvent.recurrenceEndDate = result.recurrenceEndDate;
+    liveEvent.slots = result.slots;
+  }
+
+  liveEvent.status = computeLiveEventStatus(liveEvent);
+  await liveEvent.save();
+
+  await refreshEventCalendar();
+
+  channelLog(
+    generateSystemLogContent('Live Event Edited', {
+      event: `\`${liveEvent.name}\``,
+      id: `\`${eventId}\``,
+      editor: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  return interaction.editReply(`✅ **${liveEvent.name}** updated successfully.`);
+}

--- a/src/service/interaction/is-chat-input-command/live-event-info.js
+++ b/src/service/interaction/is-chat-input-command/live-event-info.js
@@ -1,0 +1,127 @@
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateInteractionCreateLogContent } from '../../utils/channel-log.js';
+import {
+  discordTimestamp,
+  getNextOccurrence,
+  getCurrentOccurrence,
+  computeLiveEventStatus,
+} from '../../utils/live-event-utils.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/**
+ * /live-event info
+ */
+export default async function liveEventInfo(interaction) {
+  await interaction.deferReply({ ephemeral: false });
+
+  channelLog(generateInteractionCreateLogContent(interaction));
+
+  const eventName = interaction.options.getString('event_name');
+
+  const liveEvent = await findByIdOrName(LiveEvent, eventName);
+
+  if (!liveEvent) {
+    return interaction.editReply(`❌ No live event found with the name **${eventName}**.`);
+  }
+
+  const now = new Date();
+  const status = computeLiveEventStatus(liveEvent, now);
+
+  const statusLabel =
+    status === 'live' ? '🔴 Live now' : status === 'upcoming' ? '🕐 Upcoming' : '⚫ Ended';
+
+  const fields = [];
+
+  // Hosts
+  fields.push({
+    name: 'Host(s)',
+    value: liveEvent.hostIds.length
+      ? liveEvent.hostIds.map((id) => `<@${id}>`).join(', ')
+      : '*(none set)*',
+    inline: true,
+  });
+
+  fields.push({
+    name: 'Location',
+    value: `<#${liveEvent.locationChannelId}>`,
+    inline: true,
+  });
+  fields.push({ name: 'Status', value: statusLabel, inline: true });
+
+  // Schedule
+  const scheduleTypeLabel = liveEvent.scheduleType === 'one-time' ? '📅 One-time' : '🔁 Recurring';
+  fields.push({ name: 'Schedule Type', value: scheduleTypeLabel, inline: true });
+  fields.push({ name: 'Creator', value: `<@${liveEvent.creatorId}>`, inline: true });
+
+  if (liveEvent.scheduleType === 'one-time') {
+    const startTs = discordTimestamp(liveEvent.oneTimeDate, liveEvent.oneTimeStartTime, 'F');
+    const endTs = discordTimestamp(liveEvent.oneTimeDate, liveEvent.oneTimeEndTime, 't');
+    fields.push({ name: 'Date & Time', value: `${startTs} – ${endTs}`, inline: false });
+  } else {
+    // Recurrence period
+    const recStartTs = discordTimestamp(liveEvent.recurrenceStartDate, '00:00', 'D');
+    const recEndTs = discordTimestamp(liveEvent.recurrenceEndDate, '00:00', 'D');
+    fields.push({
+      name: 'Recurrence Period',
+      value: `${recStartTs} → ${recEndTs}`,
+      inline: false,
+    });
+
+    // Weekly slots
+    const slotLines = (liveEvent.slots ?? [])
+      .map((s) => `${DAY_NAMES[s.dayOfWeek]} · ${s.startTime}–${s.endTime} UTC`)
+      .join('\n');
+    if (slotLines) {
+      fields.push({ name: 'Weekly Schedule', value: slotLines, inline: false });
+    }
+
+    // Exceptions count
+    const skipped = (liveEvent.skippedOccurrences ?? []).length;
+    const rescheduled = (liveEvent.rescheduledOccurrences ?? []).length;
+    if (skipped > 0 || rescheduled > 0) {
+      const parts = [];
+      if (skipped > 0) parts.push(`${skipped} skipped`);
+      if (rescheduled > 0) parts.push(`${rescheduled} rescheduled`);
+      fields.push({ name: 'Exceptions', value: parts.join(' · '), inline: true });
+    }
+  }
+
+  // Next / current occurrence
+  if (status === 'live') {
+    const curr = getCurrentOccurrence(liveEvent, now);
+    if (curr) {
+      const endTs = discordTimestamp(curr.date, curr.endTime, 't');
+      fields.push({ name: 'Ends at', value: endTs, inline: true });
+    }
+  }
+
+  const next = getNextOccurrence(liveEvent, now);
+  if (next) {
+    const nextStart = discordTimestamp(next.date, next.startTime, 'F');
+    const nextEnd = discordTimestamp(next.date, next.endTime, 't');
+    const note = next.rescheduled ? ' *(rescheduled)*' : '';
+    fields.push({
+      name: 'Next Occurrence',
+      value: `${nextStart} – ${nextEnd}${note}`,
+      inline: false,
+    });
+  }
+
+  if (liveEvent.eventPostLink) {
+    fields.push({ name: 'Event Post', value: liveEvent.eventPostLink, inline: false });
+  }
+
+  return interaction.editReply({
+    embeds: [
+      {
+        color: 0xe91e8c,
+        title: `🩷 ${liveEvent.name}`,
+        fields,
+        footer: { text: `Live Event ID: ${liveEvent._id}` },
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+}

--- a/src/service/interaction/is-chat-input-command/live-event-remove.js
+++ b/src/service/interaction/is-chat-input-command/live-event-remove.js
@@ -1,0 +1,99 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+import { hasManageEventsPermission } from '../../utils/permissions.js';
+
+/**
+ * /live-event remove
+ * Shows a confirmation prompt before permanently deleting a live event.
+ */
+export default async function liveEventRemove(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply('❌ You need the Manage Events permission to remove live events.');
+  }
+
+  const eventName = interaction.options.getString('event_name');
+
+  const liveEvent = await findByIdOrName(LiveEvent, eventName);
+
+  if (!liveEvent) {
+    return interaction.editReply(`❌ No live event found with the name **${eventName}**.`);
+  }
+
+  const eventId = liveEvent._id.toString();
+  const skipped = (liveEvent.skippedOccurrences ?? []).length;
+  const rescheduled = (liveEvent.rescheduledOccurrences ?? []).length;
+  const exceptionNote =
+    skipped + rescheduled > 0
+      ? `\n${skipped} skipped and ${rescheduled} rescheduled occurrence(s) will also be removed.`
+      : '';
+
+  const confirmRow = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`live-event-remove-confirm:${eventId}`)
+      .setLabel('Yes, delete permanently')
+      .setStyle(ButtonStyle.Danger),
+    new ButtonBuilder()
+      .setCustomId(`live-event-remove-cancel:${eventId}`)
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return interaction.editReply({
+    content:
+      `⚠️ **Permanently delete live event "${liveEvent.name}"?**\n` +
+      `This will remove the event, its schedule, and all occurrence data.${exceptionNote}\n` +
+      'This action **cannot be undone**.',
+    components: [confirmRow],
+  });
+}
+
+export async function handleLiveEventRemoveConfirm(interaction) {
+  await interaction.deferUpdate();
+
+  if (!hasManageEventsPermission(interaction)) {
+    return interaction.editReply({
+      content: '❌ You need the Manage Events permission to remove live events.',
+      components: [],
+    });
+  }
+
+  const eventId = interaction.customId.split(':')[1];
+
+  let liveEvent;
+  try {
+    liveEvent = await LiveEvent.findById(eventId);
+  } catch {
+    return interaction.editReply({ content: '❌ Invalid event ID.', components: [] });
+  }
+
+  if (!liveEvent) {
+    return interaction.editReply({ content: '❌ Live event not found.', components: [] });
+  }
+
+  await LiveEvent.findByIdAndDelete(eventId);
+
+  channelLog(
+    generateSystemLogContent('Live Event Removed', {
+      event: `\`${liveEvent.name}\``,
+      id: `\`${eventId}\``,
+      removedBy: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  await refreshEventCalendar();
+
+  return interaction.editReply({
+    content: `🗑️ Live Event **${liveEvent.name}** and all its data have been permanently deleted.`,
+    components: [],
+  });
+}
+
+export async function handleLiveEventRemoveCancel(interaction) {
+  await interaction.deferUpdate();
+  return interaction.editReply({ content: '✅ Removal cancelled.', components: [] });
+}

--- a/src/service/interaction/is-chat-input-command/live-event-reschedule.js
+++ b/src/service/interaction/is-chat-input-command/live-event-reschedule.js
@@ -1,0 +1,107 @@
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import {
+  isValidDate,
+  isValidTime,
+  isScheduledOccurrence,
+  isSkipped,
+  isRescheduled,
+  getOccurrencesBetween,
+  discordTimestamp,
+} from '../../utils/live-event-utils.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+
+/**
+ * /live-event reschedule
+ * Moves a single occurrence to a different date/time without changing the schedule.
+ */
+export default async function liveEventReschedule(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+  // Accept the old option names until the updated slash-command schema is deployed.
+  const dateStr =
+    interaction.options.getString('occurrence_date') ?? interaction.options.getString('date');
+  const startTime =
+    interaction.options.getString('occurrence_start_time') ??
+    interaction.options.getString('start_time') ??
+    null;
+  const newDateStr = interaction.options.getString('new_date');
+  const newStartTime = interaction.options.getString('new_start_time');
+  const newEndTime = interaction.options.getString('new_end_time');
+
+  if (!isValidDate(dateStr)) return interaction.editReply('❌ Invalid occurrence date. Use `YYYY-MM-DD`.');
+  if (startTime && !isValidTime(startTime)) return interaction.editReply('❌ Invalid occurrence start time. Use `HH:MM`.');
+  if (!isValidDate(newDateStr)) return interaction.editReply('❌ Invalid new date. Use `YYYY-MM-DD`.');
+  if (!isValidTime(newStartTime)) return interaction.editReply('❌ Invalid new start time. Use `HH:MM`.');
+  if (!isValidTime(newEndTime)) return interaction.editReply('❌ Invalid new end time. Use `HH:MM`.');
+  if (newStartTime >= newEndTime) return interaction.editReply('❌ New start time must be before new end time.');
+
+  const liveEvent = await findByIdOrName(LiveEvent, eventName);
+  if (!liveEvent) {
+    return interaction.editReply(`❌ No live event found with the name **${eventName}**.`);
+  }
+
+  let resolvedStartTime = startTime;
+  if (!resolvedStartTime) {
+    const occurrencesOnDate = getOccurrencesBetween(liveEvent, dateStr, dateStr);
+    if (occurrencesOnDate.length === 0) {
+      return interaction.editReply(`❌ No scheduled occurrence found on \`${dateStr}\`.`);
+    }
+    if (occurrencesOnDate.length > 1) {
+      const slots = occurrencesOnDate.map((occurrence) => `\`${occurrence.startTime}\``).join(', ');
+      return interaction.editReply(
+        `❌ Multiple occurrences found on \`${dateStr}\` (${slots}). Provide the occurrence start time to identify which one to move.`,
+      );
+    }
+    resolvedStartTime = occurrencesOnDate[0].originalStartTime ?? occurrencesOnDate[0].startTime;
+  } else if (!isScheduledOccurrence(liveEvent, dateStr, resolvedStartTime)) {
+    return interaction.editReply(`❌ No scheduled occurrence found on \`${dateStr}\` at \`${resolvedStartTime}\`.`);
+  }
+
+  if (isSkipped(liveEvent, dateStr, resolvedStartTime)) {
+    return interaction.editReply(
+      '❌ That occurrence is currently skipped. Unskip it before rescheduling.',
+    );
+  }
+
+  // Replace existing reschedule if one exists for this slot
+  if (isRescheduled(liveEvent, dateStr, resolvedStartTime)) {
+    liveEvent.rescheduledOccurrences = liveEvent.rescheduledOccurrences.filter(
+      (r) => !(r.originalDate === dateStr && r.originalStartTime === resolvedStartTime),
+    );
+  }
+
+  liveEvent.rescheduledOccurrences.push({
+    originalDate: dateStr,
+    originalStartTime: resolvedStartTime,
+    newDate: newDateStr,
+    newStartTime,
+    newEndTime,
+    rescheduledBy: interaction.user.id,
+  });
+
+  await liveEvent.save();
+  await refreshEventCalendar();
+
+  channelLog(
+    generateSystemLogContent('Live Event Occurrence Rescheduled', {
+      event: `\`${liveEvent.name}\``,
+      original: `\`${dateStr}\` at \`${resolvedStartTime}\``,
+      replacement: `\`${newDateStr}\` \`${newStartTime}\`–\`${newEndTime}\``,
+      by: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  const originalTs = discordTimestamp(dateStr, resolvedStartTime, 'F');
+  const newTs = discordTimestamp(newDateStr, newStartTime, 'F');
+  const newEndTs = discordTimestamp(newDateStr, newEndTime, 't');
+
+  return interaction.editReply(
+    `✅ Rescheduled one occurrence of **${liveEvent.name}**.\n\n` +
+      `**Original:** ${originalTs}\n` +
+      `**New time:** ${newTs} – ${newEndTs}\n\n` +
+      'The recurring schedule is unchanged. Only this occurrence has been moved.',
+  );
+}

--- a/src/service/interaction/is-chat-input-command/live-event-skip.js
+++ b/src/service/interaction/is-chat-input-command/live-event-skip.js
@@ -1,0 +1,160 @@
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import {
+  isValidDate,
+  isValidTime,
+  isSkipped,
+  getOccurrencesBetween,
+  discordTimestamp,
+} from '../../utils/live-event-utils.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+
+/**
+ * /live-event skip
+ * Cancels one or more occurrences without modifying the recurring schedule.
+ */
+export default async function liveEventSkip(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = interaction.options.getString('event_name');
+  const dateStr = interaction.options.getString('date');
+  const startTime = interaction.options.getString('start_time') ?? null;
+  const endDateStr = interaction.options.getString('end_date') ?? null;
+
+  if (!isValidDate(dateStr)) {
+    return interaction.editReply('❌ Invalid date. Use format `YYYY-MM-DD`.');
+  }
+  if (startTime && !isValidTime(startTime)) {
+    return interaction.editReply('❌ Invalid start time. Use format `HH:MM`.');
+  }
+  if (endDateStr) {
+    if (!isValidDate(endDateStr)) {
+      return interaction.editReply('❌ Invalid end date. Use format `YYYY-MM-DD`.');
+    }
+    if (endDateStr < dateStr) {
+      return interaction.editReply('❌ End date must be on or after the start date.');
+    }
+  }
+
+  const liveEvent = await findByIdOrName(LiveEvent, eventName);
+  if (!liveEvent) {
+    return interaction.editReply(`❌ No live event found with the name **${eventName}**.`);
+  }
+
+  // Collect targets
+  let targets;
+
+  if (endDateStr) {
+    targets = getOccurrencesBetween(liveEvent, dateStr, endDateStr);
+    if (startTime) targets = targets.filter((o) => o.startTime === startTime);
+    if (targets.length === 0) {
+      return interaction.editReply(
+        `❌ No scheduled occurrences found between \`${dateStr}\` and \`${endDateStr}\`${startTime ? ` at \`${startTime}\`` : ''}.`,
+      );
+    }
+  } else {
+    const onDate = getOccurrencesBetween(liveEvent, dateStr, dateStr);
+    const movedToDate = (liveEvent.rescheduledOccurrences ?? [])
+      .filter(
+        (rescheduled) =>
+          rescheduled.newDate === dateStr &&
+          (!startTime || rescheduled.newStartTime === startTime),
+      )
+      .map((rescheduled) => ({
+        date: rescheduled.newDate,
+        startTime: rescheduled.newStartTime,
+        originalDate: rescheduled.originalDate,
+        originalStartTime: rescheduled.originalStartTime,
+      }));
+    const movedFromDate = (liveEvent.rescheduledOccurrences ?? [])
+      .filter(
+        (rescheduled) =>
+          rescheduled.originalDate === dateStr &&
+          (!startTime || rescheduled.originalStartTime === startTime),
+      )
+      .map((rescheduled) => ({
+        date: rescheduled.newDate,
+        startTime: rescheduled.newStartTime,
+        originalDate: rescheduled.originalDate,
+        originalStartTime: rescheduled.originalStartTime,
+      }));
+
+    const candidates = [...onDate, ...movedToDate, ...movedFromDate].filter(
+      (occurrence, index, all) =>
+        all.findIndex(
+          (candidate) =>
+            (candidate.originalDate ?? candidate.date) ===
+              (occurrence.originalDate ?? occurrence.date) &&
+            (candidate.originalStartTime ?? candidate.startTime) ===
+              (occurrence.originalStartTime ?? occurrence.startTime),
+        ) === index,
+    );
+
+    if (candidates.length === 0) {
+      return interaction.editReply(
+        `❌ No scheduled occurrence on \`${dateStr}\`. Check the date falls within the recurrence period.`,
+      );
+    }
+    if (!startTime && candidates.length > 1) {
+      const slots = candidates.map((o) => `\`${o.startTime}\``).join(', ');
+      return interaction.editReply(
+        `❌ Multiple slots on \`${dateStr}\` (${slots}). Provide \`start_time\` to specify which one.`,
+      );
+    }
+    targets = startTime ? candidates.filter((o) => o.startTime === startTime) : candidates;
+    if (targets.length === 0) {
+      return interaction.editReply(
+        `❌ No occurrence found for \`${dateStr}\` at \`${startTime}\`.`,
+      );
+    }
+  }
+
+  let newlySkipped = 0;
+  let alreadySkipped = 0;
+
+  for (const occ of targets) {
+    const originalDate = occ.originalDate ?? occ.date;
+    const originalStartTime = occ.originalStartTime ?? occ.startTime;
+
+    if (isSkipped(liveEvent, originalDate, originalStartTime)) {
+      alreadySkipped++;
+      continue;
+    }
+    liveEvent.skippedOccurrences.push({
+      date: originalDate,
+      startTime: originalStartTime,
+      skippedBy: interaction.user.id,
+    });
+    newlySkipped++;
+  }
+
+  if (newlySkipped === 0) {
+    return interaction.editReply(
+      `ℹ️ ${alreadySkipped === 1 ? 'That occurrence was' : 'All those occurrences were'} already skipped.`,
+    );
+  }
+
+  await liveEvent.save();
+  await refreshEventCalendar();
+
+  channelLog(
+    generateSystemLogContent('Live Event Occurrences Skipped', {
+      event: `\`${liveEvent.name}\``,
+      count: `\`${newlySkipped}\``,
+      by: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  const lines = targets
+    .slice(0, 10)
+    .map((o) => `  • ${discordTimestamp(o.date, o.startTime, 'F')}`)
+    .join('\n');
+  const overflow = targets.length > 10 ? `\n  *(and ${targets.length - 10} more)*` : '';
+
+  let reply = `✅ Skipped **${newlySkipped}** occurrence${newlySkipped === 1 ? '' : 's'} of **${liveEvent.name}**.`;
+  if (alreadySkipped > 0) reply += ` *(${alreadySkipped} already skipped)*`;
+  if (lines) reply += `\n${lines}${overflow}`;
+
+  return interaction.editReply(reply);
+}

--- a/src/service/interaction/is-chat-input-command/live-event-unskip.js
+++ b/src/service/interaction/is-chat-input-command/live-event-unskip.js
@@ -1,0 +1,122 @@
+import LiveEvent from '../../../models/live-event.js';
+import channelLog, { generateSystemLogContent } from '../../utils/channel-log.js';
+import { refreshEventCalendar } from '../../utils/event-calendar.js';
+import {
+  isValidDate,
+  isValidTime,
+  computeLiveEventStatus,
+  discordTimestamp,
+} from '../../utils/live-event-utils.js';
+import { findByIdOrName } from '../../utils/event-utils.js';
+
+function getLiveEventName(interaction) {
+  const selectedName = interaction.options.getString('event_name');
+  return selectedName.replace(/\s+\[(?:Recurring|One-time)\s+·\s+[^\]]+\]$/, '');
+}
+
+/**
+ * /live-event unskip
+ * Restores one or more previously skipped occurrences.
+ */
+export default async function liveEventUnskip(interaction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const eventName = getLiveEventName(interaction);
+  const dateStr = interaction.options.getString('date');
+  const startTime = interaction.options.getString('start_time') ?? null;
+  const endDateStr = interaction.options.getString('end_date') ?? null;
+
+  if (!isValidDate(dateStr)) {
+    return interaction.editReply('❌ Invalid date. Use format `YYYY-MM-DD`.');
+  }
+  if (startTime && !isValidTime(startTime)) {
+    return interaction.editReply('❌ Invalid start time. Use format `HH:MM`.');
+  }
+  if (endDateStr) {
+    if (!isValidDate(endDateStr)) {
+      return interaction.editReply('❌ Invalid end date. Use format `YYYY-MM-DD`.');
+    }
+    if (endDateStr < dateStr) {
+      return interaction.editReply('❌ End date must be on or after the start date.');
+    }
+  }
+
+  const liveEvent = await findByIdOrName(LiveEvent, eventName);
+  if (!liveEvent) {
+    return interaction.editReply(`❌ No live event found with the name **${eventName}**.`);
+  }
+
+  if ((liveEvent.skippedOccurrences ?? []).length === 0) {
+    return interaction.editReply(`ℹ️ **${liveEvent.name}** has no skipped occurrences.`);
+  }
+
+  const rescheduledByOriginal = new Map(
+    (liveEvent.rescheduledOccurrences ?? []).map((rescheduled) => [
+      `${rescheduled.originalDate}|${rescheduled.originalStartTime}`,
+      rescheduled,
+    ]),
+  );
+
+  const matchesRequestedOccurrence = (skipped) => {
+    const rescheduled = rescheduledByOriginal.get(`${skipped.date}|${skipped.startTime}`);
+    const dateMatches = (candidateDate) =>
+      candidateDate === skipped.date || candidateDate === rescheduled?.newDate;
+    const timeMatches = (candidateStartTime) =>
+      !startTime ||
+      candidateStartTime === skipped.startTime ||
+      candidateStartTime === rescheduled?.newStartTime;
+
+    return dateMatches(dateStr) && timeMatches(startTime);
+  };
+
+  // Find matching skipped entries
+  let targets;
+  if (endDateStr) {
+    targets = liveEvent.skippedOccurrences.filter(
+      (s) => {
+        const rescheduled = rescheduledByOriginal.get(`${s.date}|${s.startTime}`);
+        const candidateDates = [s.date, rescheduled?.newDate].filter(Boolean);
+        return (
+          candidateDates.some(
+            (candidateDate) => candidateDate >= dateStr && candidateDate <= endDateStr,
+          ) &&
+          (!startTime || s.startTime === startTime || rescheduled?.newStartTime === startTime)
+        );
+      },
+    );
+  } else {
+    targets = liveEvent.skippedOccurrences.filter(matchesRequestedOccurrence);
+  }
+
+  if (targets.length === 0) {
+    return interaction.editReply('❌ No skipped occurrences found matching the given criteria.');
+  }
+
+  const targetKeys = new Set(targets.map((s) => `${s.date}|${s.startTime}`));
+  liveEvent.skippedOccurrences = liveEvent.skippedOccurrences.filter(
+    (s) => !targetKeys.has(`${s.date}|${s.startTime}`),
+  );
+
+  liveEvent.status = computeLiveEventStatus(liveEvent);
+  await liveEvent.save();
+
+  await refreshEventCalendar();
+
+  channelLog(
+    generateSystemLogContent('Live Event Occurrences Unskipped', {
+      event: `\`${liveEvent.name}\``,
+      count: `\`${targets.length}\``,
+      by: `<@${interaction.user.id}>`,
+    }),
+  );
+
+  const lines = targets
+    .slice(0, 10)
+    .map((s) => `  • ${discordTimestamp(s.date, s.startTime, 'F')}`)
+    .join('\n');
+  const overflow = targets.length > 10 ? `\n  *(and ${targets.length - 10} more)*` : '';
+
+  return interaction.editReply(
+    `✅ Restored **${targets.length}** skipped occurrence${targets.length === 1 ? '' : 's'} of **${liveEvent.name}**.\n${lines}${overflow}`,
+  );
+}

--- a/src/service/messageCreate/event-submission.js
+++ b/src/service/messageCreate/event-submission.js
@@ -1,10 +1,10 @@
-import Event from '../../models/event.js';
 import EventParticipant from '../../models/event-participant.js';
 import EventSubmission from '../../models/event-submission.js';
 import EventBan from '../../models/event-ban.js';
 import channelLog, { generateSystemLogContent } from '../utils/channel-log.js';
 import {
   findActiveEventForChannel,
+  incrementParticipantTotals,
   messageContainsHashtag,
   updateLiveLeaderboard,
 } from '../utils/event-utils.js';
@@ -46,10 +46,7 @@ export default async function eventSubmission(message) {
     if (existingSubmission) return;
 
     // Fetch or create the participant record
-    let participant = await EventParticipant.findOne({ eventId, userId });
-    if (!participant) {
-      participant = new EventParticipant({ eventId, userId, points: 0, submissionCount: 0 });
-    }
+    const participant = await EventParticipant.findOne({ eventId, userId });
 
     // If no points configured, just count the submission with no points awarded
     if (!event.pointsPerSubmission) {
@@ -61,8 +58,7 @@ export default async function eventSubmission(message) {
         pointsAwarded: 0,
       });
       await submission.save();
-      participant.submissionCount += 1;
-      await participant.save();
+      await incrementParticipantTotals({ eventId, userId, submissionCount: 1 });
       await message.react('✅').catch(() => {});
       return;
     }
@@ -88,9 +84,12 @@ export default async function eventSubmission(message) {
     await submission.save();
 
     // Update participant totals
-    participant.points += pointsAwarded;
-    participant.submissionCount += 1;
-    await participant.save();
+    const updatedParticipant = await incrementParticipantTotals({
+      eventId,
+      userId,
+      points: pointsAwarded,
+      submissionCount: 1,
+    });
 
     // React to the message so the participant knows their submission was counted
     await message.react('✅').catch(() => {});
@@ -99,7 +98,7 @@ export default async function eventSubmission(message) {
       generateSystemLogContent('Event Submission Counted', {
         event: `\`${event.name}\``,
         user: `<@${userId}>`,
-        points: `\`+${pointsAwarded}\` (total: \`${participant.points}/${event.maxPoints}\`)`,
+        points: `\`+${pointsAwarded}\` (total: \`${updatedParticipant.points}/${event.maxPoints}\`)`,
         channel: `<#${channelId}>`,
       }),
     );

--- a/src/service/messageCreate/event-submission.js
+++ b/src/service/messageCreate/event-submission.js
@@ -1,0 +1,112 @@
+import Event from '../../models/event.js';
+import EventParticipant from '../../models/event-participant.js';
+import EventSubmission from '../../models/event-submission.js';
+import EventBan from '../../models/event-ban.js';
+import channelLog, { generateSystemLogContent } from '../utils/channel-log.js';
+import {
+  findActiveEventForChannel,
+  messageContainsHashtag,
+  updateLiveLeaderboard,
+} from '../utils/event-utils.js';
+
+/**
+ * Called for every non-bot message.
+ * Checks whether the message is a valid event submission and records it.
+ */
+export default async function eventSubmission(message) {
+  try {
+    const channelId = message.channelId ?? message.channel?.id;
+    if (!channelId) return;
+
+    // Find an active event that tracks this channel
+    const event = await findActiveEventForChannel(channelId);
+    if (!event) return;
+
+    const userId = message.author.id;
+    const messageId = message.id;
+    const eventId = event._id.toString();
+
+    // Check the message contains the event's hashtag
+    if (!messageContainsHashtag(message.content, event.hashtag)) return;
+
+    // Check if the user is banned from this event
+    const ban = await EventBan.findOne({ eventId, userId });
+    if (ban) {
+      await message.react('❌').catch(() => {});
+      await message
+        .reply({
+          content: `You are banned from participating in **${event.name}**. Please contact a moderator for further information.`,
+        })
+        .catch(() => {});
+      return;
+    }
+
+    // Deduplicate: has this exact message already been counted?
+    const existingSubmission = await EventSubmission.findOne({ eventId, messageId });
+    if (existingSubmission) return;
+
+    // Fetch or create the participant record
+    let participant = await EventParticipant.findOne({ eventId, userId });
+    if (!participant) {
+      participant = new EventParticipant({ eventId, userId, points: 0, submissionCount: 0 });
+    }
+
+    // If no points configured, just count the submission with no points awarded
+    if (!event.pointsPerSubmission) {
+      const submission = new EventSubmission({
+        eventId,
+        userId,
+        messageId,
+        channelId,
+        pointsAwarded: 0,
+      });
+      await submission.save();
+      participant.submissionCount += 1;
+      await participant.save();
+      await message.react('✅').catch(() => {});
+      return;
+    }
+
+    // Check if the participant has already hit the max points cap
+    if (participant.points >= event.maxPoints) {
+      await message.react('🔒').catch(() => {});
+      return;
+    }
+
+    // Calculate how many points to award (may be less than pointsPerSubmission at cap)
+    const remaining = event.maxPoints - participant.points;
+    const pointsAwarded = Math.min(event.pointsPerSubmission, remaining);
+
+    // Save the submission record
+    const submission = new EventSubmission({
+      eventId,
+      userId,
+      messageId,
+      channelId,
+      pointsAwarded,
+    });
+    await submission.save();
+
+    // Update participant totals
+    participant.points += pointsAwarded;
+    participant.submissionCount += 1;
+    await participant.save();
+
+    // React to the message so the participant knows their submission was counted
+    await message.react('✅').catch(() => {});
+
+    channelLog(
+      generateSystemLogContent('Event Submission Counted', {
+        event: `\`${event.name}\``,
+        user: `<@${userId}>`,
+        points: `\`+${pointsAwarded}\` (total: \`${participant.points}/${event.maxPoints}\`)`,
+        channel: `<#${channelId}>`,
+      }),
+    );
+
+    // Update the pinned leaderboard message (no-op if not posted or already locked)
+    await updateLiveLeaderboard(event);
+  } catch (err) {
+    console.error('Error processing event submission:', err);
+  }
+}

--- a/src/service/schedules/event-lifecycle.js
+++ b/src/service/schedules/event-lifecycle.js
@@ -1,0 +1,65 @@
+import Event from '../../models/event.js';
+import channelLog, { generateSystemLogContent } from '../utils/channel-log.js';
+
+/**
+ * Runs every hour.
+ * - Activates pending events whose start time has passed.
+ * - Closes active events whose end time has passed.
+ *
+ * Events are never auto-deleted when they end — they remain available
+ * for leaderboard viewing and point export until explicitly removed.
+ */
+export default async function eventLifecycle() {
+  try {
+    const now = new Date();
+
+    // ── Activate pending events ──────────────────────────────────────────────
+    const toActivate = await Event.find({
+      status: 'pending',
+      startDate: { $lte: now },
+    });
+
+    for (const event of toActivate) {
+      event.status = 'active';
+      await event.save();
+
+      channelLog(
+        generateSystemLogContent('Event Activated', {
+          event: `\`${event.name}\``,
+          id: `\`${event._id}\``,
+          startDate: `\`${event.startDate.toISOString()}\``,
+        }),
+      );
+    }
+
+    // ── Close active events ──────────────────────────────────────────────────
+    const toClose = await Event.find({
+      status: 'active',
+      endDate: { $lte: now },
+    });
+
+    for (const event of toClose) {
+      event.status = 'ended';
+      await event.save();
+
+      channelLog(
+        generateSystemLogContent('Event Ended', {
+          event: `\`${event.name}\``,
+          id: `\`${event._id}\``,
+          endDate: `\`${event.endDate.toISOString()}\``,
+        }),
+      );
+    }
+
+    if (toActivate.length > 0 || toClose.length > 0) {
+      channelLog(
+        generateSystemLogContent('Event Lifecycle Run', {
+          activated: `\`${toActivate.length}\``,
+          closed: `\`${toClose.length}\``,
+        }),
+      );
+    }
+  } catch (err) {
+    console.error('Error in eventLifecycle:', err);
+  }
+}

--- a/src/service/schedules/event-lifecycle.js
+++ b/src/service/schedules/event-lifecycle.js
@@ -1,64 +1,68 @@
 import Event from '../../models/event.js';
+import LiveEvent from '../../models/live-event.js';
 import channelLog, { generateSystemLogContent } from '../utils/channel-log.js';
 import { refreshEventCalendar } from '../utils/event-calendar.js';
+import { computeLiveEventStatus } from '../utils/live-event-utils.js';
 
 /**
- * Runs every hour.
- * - Activates pending events whose start time has passed.
- * - Closes active events whose end time has passed.
+ * Runs every hour and on startup.
  *
- * Events are never auto-deleted when they end — they remain available
- * for leaderboard viewing and point export until explicitly removed.
+ * Standard events: pending → active → ended based on startDate/endDate.
+ * Live events: upcoming → live → ended based on scheduled occurrences.
  */
 export default async function eventLifecycle() {
   try {
     const now = new Date();
+    let changed = 0;
 
-    // ── Activate pending events ──────────────────────────────────────────────
-    const toActivate = await Event.find({
-      status: 'pending',
-      startDate: { $lte: now },
-    });
-
+    // ── Standard events ───────────────────────────────────────────────────────
+    const toActivate = await Event.find({ status: 'pending', startDate: { $lte: now } });
     for (const event of toActivate) {
       event.status = 'active';
       await event.save();
-
+      changed++;
       channelLog(
         generateSystemLogContent('Event Activated', {
           event: `\`${event.name}\``,
           id: `\`${event._id}\``,
-          startDate: `\`${event.startDate.toISOString()}\``,
         }),
       );
     }
 
-    // ── Close active events ──────────────────────────────────────────────────
-    const toClose = await Event.find({
-      status: 'active',
-      endDate: { $lte: now },
-    });
-
+    const toClose = await Event.find({ status: 'active', endDate: { $lte: now } });
     for (const event of toClose) {
       event.status = 'ended';
       await event.save();
-
+      changed++;
       channelLog(
         generateSystemLogContent('Event Ended', {
           event: `\`${event.name}\``,
           id: `\`${event._id}\``,
-          endDate: `\`${event.endDate.toISOString()}\``,
         }),
       );
     }
 
-    if (toActivate.length > 0 || toClose.length > 0) {
-      channelLog(
-        generateSystemLogContent('Event Lifecycle Run', {
-          activated: `\`${toActivate.length}\``,
-          closed: `\`${toClose.length}\``,
-        }),
-      );
+    // ── Live events ───────────────────────────────────────────────────────────
+    const liveEvents = await LiveEvent.find({ status: { $in: ['upcoming', 'live'] } });
+    for (const liveEvent of liveEvents) {
+      const newStatus = computeLiveEventStatus(liveEvent, now);
+      if (liveEvent.status !== newStatus) {
+        const old = liveEvent.status;
+        liveEvent.status = newStatus;
+        await liveEvent.save();
+        changed++;
+        channelLog(
+          generateSystemLogContent('Live Event Status Changed', {
+            event: `\`${liveEvent.name}\``,
+            from: `\`${old}\``,
+            to: `\`${newStatus}\``,
+          }),
+        );
+      }
+    }
+
+    if (changed > 0) {
+      channelLog(generateSystemLogContent('Event Lifecycle Run', { changes: `\`${changed}\`` }));
       await refreshEventCalendar();
     }
   } catch (err) {

--- a/src/service/schedules/event-lifecycle.js
+++ b/src/service/schedules/event-lifecycle.js
@@ -1,5 +1,6 @@
 import Event from '../../models/event.js';
 import channelLog, { generateSystemLogContent } from '../utils/channel-log.js';
+import { refreshEventCalendar } from '../utils/event-calendar.js';
 
 /**
  * Runs every hour.
@@ -58,6 +59,7 @@ export default async function eventLifecycle() {
           closed: `\`${toClose.length}\``,
         }),
       );
+      await refreshEventCalendar();
     }
   } catch (err) {
     console.error('Error in eventLifecycle:', err);

--- a/src/service/utils/event-calendar.js
+++ b/src/service/utils/event-calendar.js
@@ -1,18 +1,17 @@
 import Event from '../../models/event.js';
+import LiveEvent from '../../models/live-event.js';
 import client from '../../client/index.js';
 import config from '../../config/index.js';
 import channelLog, { generateSystemLogContent } from './channel-log.js';
+import { formatDateUTC, getOccurrencesOnDate, toUnixTimestamp } from './live-event-utils.js';
 
 const { EVENT_CALENDAR_CHANNEL_ID: calendarChannelId } = config;
-
-// ─── Category squares ─────────────────────────────────────────────────────────
 
 const CATEGORY_SQUARE = {
   Reading: '🟥',
   Listening: '🟨',
   Speaking: '🟦',
   Writing: '🟩',
-  'Live Event': '🩷',
   Mixed: '🟧',
   Other: '🟪',
 };
@@ -20,13 +19,9 @@ const CATEGORY_SQUARE = {
 const LEGEND =
   '🟥 Reading · 🟨 Listening · 🟦 Speaking · 🟩 Writing · 🩷 Live Event · 🟧 Mixed · 🟪 Other';
 
-// ─── Embed builder ────────────────────────────────────────────────────────────
+// ─── Standard events embed ────────────────────────────────────────────────────
 
-/**
- * Builds a single embed showing all currently active events.
- * Each event appears once as a line item — no day-by-day expansion.
- */
-function buildCalendarEmbed(events) {
+function buildStandardEmbed(events, liveEvents) {
   const today = new Date().toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'long',
@@ -34,7 +29,7 @@ function buildCalendarEmbed(events) {
     timeZone: 'UTC',
   });
 
-  if (events.length === 0) {
+  if (events.length === 0 && liveEvents.length === 0) {
     return {
       color: 0x5865f2,
       title: '🗓️ Language Cafe Event Calendar',
@@ -48,21 +43,33 @@ function buildCalendarEmbed(events) {
     return `${square} ${name}`;
   });
 
+  const liveLines = liveEvents.map(({ liveEvent, occurrences }) => {
+    const name = liveEvent.eventPostLink
+      ? `[${liveEvent.name}](${liveEvent.eventPostLink})`
+      : liveEvent.name;
+    const hosts = liveEvent.hostIds?.length
+      ? ` · ${liveEvent.hostIds.map((id) => `<@${id}>`).join(', ')}`
+      : '';
+    const times = occurrences
+      .map(
+        (occurrence) =>
+          `<t:${toUnixTimestamp(occurrence.date, occurrence.startTime)}:t>–<t:${toUnixTimestamp(occurrence.date, occurrence.endTime)}:t>`,
+      )
+      .join(', ');
+
+    return `🩷 ${name} · ${times}${hosts} · <#${liveEvent.locationChannelId}>`;
+  });
+
   return {
     color: 0x5865f2,
     title: '🗓️ Language Cafe Event Calendar',
-    description: `**Today's Events · ${today}**\n${LEGEND}\n\n` + lines.join('\n'),
+    description:
+      `**Today's Events · ${today}**\n${LEGEND}\n\n` + [...lines, ...liveLines].join('\n'),
   };
 }
 
 // ─── Channel refresh ──────────────────────────────────────────────────────────
 
-/**
- * Clears all bot messages in the #event-calendar channel and reposts
- * a single embed listing all currently active events.
- *
- * No-op if EVENT_CALENDAR_CHANNEL_ID is not configured.
- */
 export async function refreshEventCalendar() {
   try {
     if (!calendarChannelId) return;
@@ -84,14 +91,26 @@ export async function refreshEventCalendar() {
       }
     }
 
-    // Fetch active events sorted by start date
+    // Fetch active standard events
     const events = await Event.find({ status: 'active' }).sort({ startDate: 1 });
 
-    await channel.send({ embeds: [buildCalendarEmbed(events)] });
+    // Only include live-event series with an occurrence scheduled for today.
+    const todayStr = formatDateUTC(new Date());
+    const liveEvents = (await LiveEvent.find({ status: { $in: ['upcoming', 'live'] } }))
+      .map((liveEvent) => ({
+        liveEvent,
+        occurrences: getOccurrencesOnDate(liveEvent, todayStr),
+      }))
+      .filter(({ occurrences }) => occurrences.length > 0);
+
+    await channel.send({
+      embeds: [buildStandardEmbed(events, liveEvents)],
+    });
 
     channelLog(
       generateSystemLogContent('Event Calendar Refreshed', {
         activeEvents: `\`${events.length}\``,
+        liveEvents: `\`${liveEvents.length}\``,
       }),
     );
   } catch (err) {

--- a/src/service/utils/event-calendar.js
+++ b/src/service/utils/event-calendar.js
@@ -1,0 +1,100 @@
+import Event from '../../models/event.js';
+import client from '../../client/index.js';
+import config from '../../config/index.js';
+import channelLog, { generateSystemLogContent } from './channel-log.js';
+
+const { EVENT_CALENDAR_CHANNEL_ID: calendarChannelId } = config;
+
+// ─── Category squares ─────────────────────────────────────────────────────────
+
+const CATEGORY_SQUARE = {
+  Reading: '🟥',
+  Listening: '🟨',
+  Speaking: '🟦',
+  Writing: '🟩',
+  'Live Event': '🩷',
+  Mixed: '🟧',
+  Other: '🟪',
+};
+
+const LEGEND =
+  '🟥 Reading · 🟨 Listening · 🟦 Speaking · 🟩 Writing · 🩷 Live Event · 🟧 Mixed · 🟪 Other';
+
+// ─── Embed builder ────────────────────────────────────────────────────────────
+
+/**
+ * Builds a single embed showing all currently active events.
+ * Each event appears once as a line item — no day-by-day expansion.
+ */
+function buildCalendarEmbed(events) {
+  const today = new Date().toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  if (events.length === 0) {
+    return {
+      color: 0x5865f2,
+      title: '🗓️ Language Cafe Event Calendar',
+      description: `**Today's Events · ${today}**\n${LEGEND}\n\n*No active events at the moment.*`,
+    };
+  }
+
+  const lines = events.map((event) => {
+    const square = CATEGORY_SQUARE[event.eventType] ?? '🟪';
+    const name = event.eventPostLink ? `[${event.name}](${event.eventPostLink})` : event.name;
+    return `${square} ${name}`;
+  });
+
+  return {
+    color: 0x5865f2,
+    title: '🗓️ Language Cafe Event Calendar',
+    description: `**Today's Events · ${today}**\n${LEGEND}\n\n` + lines.join('\n'),
+  };
+}
+
+// ─── Channel refresh ──────────────────────────────────────────────────────────
+
+/**
+ * Clears all bot messages in the #event-calendar channel and reposts
+ * a single embed listing all currently active events.
+ *
+ * No-op if EVENT_CALENDAR_CHANNEL_ID is not configured.
+ */
+export async function refreshEventCalendar() {
+  try {
+    if (!calendarChannelId) return;
+
+    const channel = await client.channels.fetch(calendarChannelId).catch(() => null);
+    if (!channel) return;
+
+    // Delete existing bot messages
+    const messages = await channel.messages.fetch({ limit: 100 });
+    const botMessages = messages.filter((m) => m.author.id === client.user.id);
+
+    if (botMessages.size > 0) {
+      try {
+        await channel.bulkDelete(botMessages);
+      } catch {
+        for (const msg of botMessages.values()) {
+          await msg.delete().catch(() => {});
+        }
+      }
+    }
+
+    // Fetch active events sorted by start date
+    const events = await Event.find({ status: 'active' }).sort({ startDate: 1 });
+
+    await channel.send({ embeds: [buildCalendarEmbed(events)] });
+
+    channelLog(
+      generateSystemLogContent('Event Calendar Refreshed', {
+        activeEvents: `\`${events.length}\``,
+      }),
+    );
+  } catch (err) {
+    console.error('refreshEventCalendar error:', err);
+  }
+}

--- a/src/service/utils/event-utils.js
+++ b/src/service/utils/event-utils.js
@@ -1,0 +1,180 @@
+import { time } from 'discord.js';
+import EventParticipant from '../../models/event-participant.js';
+import EventLeaderboard from '../../models/event-leaderboard.js';
+import Event from '../../models/event.js';
+import client from '../../client/index.js';
+
+// ─── Colour map by event type ───────────────────────────────────────────────
+
+const EVENT_TYPE_COLORS = {
+  Reading: 0x4a90d9,
+  Listening: 0x9b59b6,
+  Speaking: 0xe67e22,
+  Writing: 0x2ecc71,
+  'Live Event': 0xe74c3c,
+  Mixed: 0xf39c12,
+  Other: 0x95a5a6,
+};
+
+const EVENT_TYPE_EMOJIS = {
+  Reading: '📚',
+  Listening: '🎧',
+  Speaking: '🗣️',
+  Writing: '✍️',
+  'Live Event': '🔴',
+  Mixed: '🌐',
+  Other: '📌',
+};
+
+// ─── Calendar embed builder ──────────────────────────────────────────────────
+
+/**
+ * Build a single Discord embed for an event (used by /calendar and /event info).
+ */
+export function buildCalendarEmbed(event) {
+  const emoji = EVENT_TYPE_EMOJIS[event.eventType] ?? '📌';
+  const color = EVENT_TYPE_COLORS[event.eventType] ?? 0x95a5a6;
+
+  const statusLabel =
+    event.status === 'active' ? '🟢 Active' : event.status === 'ended' ? '⚫ Ended' : '🕐 Upcoming';
+
+  const fields = [
+    { name: 'Type', value: `${emoji} ${event.eventType}`, inline: true },
+    { name: 'Status', value: statusLabel, inline: true },
+    { name: 'Channel', value: `<#${event.submissionChannelId}>`, inline: true },
+    {
+      name: 'Start',
+      value: time(Math.floor(event.startDate.getTime() / 1000), 'F'),
+      inline: true,
+    },
+    {
+      name: 'End',
+      value: time(Math.floor(event.endDate.getTime() / 1000), 'F'),
+      inline: true,
+    },
+    { name: 'Hashtag', value: `\`${event.hashtag}\``, inline: true },
+  ];
+
+  if (event.eventPostLink) {
+    fields.push({ name: 'Event Post', value: event.eventPostLink, inline: false });
+  }
+
+  return {
+    color,
+    title: event.name,
+    fields,
+    footer: { text: `Event ID: ${event._id}` },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ─── Live leaderboard embed builder ─────────────────────────────────────────
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+/**
+ * Build the pinned leaderboard embed showing top 3 participants.
+ * Sorted by points descending, then by earliest submission (createdAt ascending)
+ * to break ties in favour of whoever reached that score first.
+ */
+export async function buildLiveLeaderboardEmbed(event) {
+  const color = EVENT_TYPE_COLORS[event.eventType] ?? 0x95a5a6;
+  const emoji = EVENT_TYPE_EMOJIS[event.eventType] ?? '📌';
+  const eventId = event._id.toString();
+
+  const totalParticipants = await EventParticipant.countDocuments({ eventId });
+
+  const top3 = await EventParticipant.find({ eventId })
+    .sort({ points: -1, createdAt: 1 })
+    .limit(3)
+    .lean();
+
+  const subtitle = event.pointsPerSubmission
+    ? `Leaderboard · ${totalParticipants} participant${totalParticipants === 1 ? '' : 's'} · ${event.pointsPerSubmission} pts/submission · ${event.maxPoints} pt maximum`
+    : `Leaderboard · ${totalParticipants} participant${totalParticipants === 1 ? '' : 's'}`;
+
+  let description;
+  if (top3.length === 0) {
+    description = '*No submissions yet. Be the first!*';
+  } else {
+    const rows = top3.map((p, i) =>
+      event.pointsPerSubmission
+        ? `${MEDALS[i]}　<@${p.userId}>　**${p.points}**`
+        : `${MEDALS[i]}　<@${p.userId}>　${p.submissionCount} submission${p.submissionCount === 1 ? '' : 's'}`,
+    );
+    description = rows.join('\n');
+  }
+
+  return {
+    color,
+    title: `${emoji} ${event.name}`,
+    description: `${subtitle}\n\n${description}`,
+  };
+}
+
+// ─── Live leaderboard update ─────────────────────────────────────────────────
+
+/**
+ * Fetch the stored leaderboard record for an event, edit the pinned message,
+ * and lock it if 3 participants have now reached max points.
+ *
+ * Safe to call on every submission — skips silently if no leaderboard is posted
+ * or if already locked.
+ */
+export async function updateLiveLeaderboard(event) {
+  try {
+    const eventId = event._id.toString();
+    const record = await EventLeaderboard.findOne({ eventId });
+    if (!record || record.isLocked) return;
+
+    const channel = await client.channels.fetch(record.channelId);
+    if (!channel) return;
+
+    const message = await channel.messages.fetch(record.messageId);
+    if (!message) return;
+
+    const embed = await buildLiveLeaderboardEmbed(event);
+    await message.edit({ embeds: [embed] });
+
+    // Lock once 3 participants have reached the max points cap
+    const maxedCount = await EventParticipant.countDocuments({
+      eventId,
+      points: event.maxPoints,
+    });
+
+    if (maxedCount >= 3) {
+      record.isLocked = true;
+      await record.save();
+    }
+  } catch (err) {
+    console.error('updateLiveLeaderboard error:', err);
+  }
+}
+
+// ─── Event lookup helpers ────────────────────────────────────────────────────
+
+/**
+ * Find an active event that tracks the given channel.
+ */
+export async function findActiveEventForChannel(channelId) {
+  return Event.findOne({
+    status: 'active',
+    submissionChannelId: channelId,
+  });
+}
+
+/**
+ * Normalise a hashtag so it always starts with #.
+ */
+export function normaliseHashtag(raw) {
+  const trimmed = raw.trim();
+  return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+}
+
+/**
+ * Check whether a message contains a specific hashtag (case-insensitive).
+ */
+export function messageContainsHashtag(content, hashtag) {
+  const normalised = normaliseHashtag(hashtag).toLowerCase();
+  return content.toLowerCase().includes(normalised);
+}

--- a/src/service/utils/event-utils.js
+++ b/src/service/utils/event-utils.js
@@ -1,4 +1,5 @@
 import { time } from 'discord.js';
+import mongoose from 'mongoose';
 import EventParticipant from '../../models/event-participant.js';
 import EventLeaderboard from '../../models/event-leaderboard.js';
 import Event from '../../models/event.js';
@@ -99,8 +100,8 @@ export async function buildLiveLeaderboardEmbed(event) {
   } else {
     const rows = top3.map((p, i) =>
       event.pointsPerSubmission
-        ? `${MEDALS[i]}　<@${p.userId}>　**${p.points}**`
-        : `${MEDALS[i]}　<@${p.userId}>　${p.submissionCount} submission${p.submissionCount === 1 ? '' : 's'}`,
+        ? `${MEDALS[i]} <@${p.userId}> **${p.points}**`
+        : `${MEDALS[i]} <@${p.userId}> ${p.submissionCount} submission${p.submissionCount === 1 ? '' : 's'}`,
     );
     description = rows.join('\n');
   }
@@ -169,6 +170,47 @@ export async function findActiveEventForChannel(channelId) {
 export function normaliseHashtag(raw) {
   const trimmed = raw.trim();
   return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export async function findByIdOrName(Model, selection) {
+  const normalizedSelection = selection.replace(
+    /\s+\[(?:Recurring|One-time)\s+·\s+[^\]]+\]$/,
+    '',
+  );
+
+  if (mongoose.isValidObjectId(normalizedSelection)) {
+    const byId = await Model.findById(normalizedSelection);
+    if (byId) return byId;
+  }
+
+  return Model.findOne({
+    name: { $regex: new RegExp(`^${escapeRegex(normalizedSelection)}$`, 'i') },
+  });
+}
+
+export async function incrementParticipantTotals({
+  eventId,
+  userId,
+  points = 0,
+  submissionCount = 0,
+}) {
+  const filter = { eventId, userId };
+  const update = { $inc: { points, submissionCount } };
+
+  try {
+    return await EventParticipant.findOneAndUpdate(filter, update, {
+      new: true,
+      upsert: true,
+      setDefaultsOnInsert: true,
+    });
+  } catch (error) {
+    if (error.code !== 11000) throw error;
+    return EventParticipant.findOneAndUpdate(filter, update, { new: true });
+  }
 }
 
 /**

--- a/src/service/utils/live-event-utils.js
+++ b/src/service/utils/live-event-utils.js
@@ -1,0 +1,572 @@
+import { time } from 'discord.js';
+
+// ─── Date / time helpers ──────────────────────────────────────────────────────
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/**
+ * Parse a "YYYY-MM-DD" date string as a UTC midnight Date.
+ * @param {string} dateStr
+ * @returns {Date}
+ */
+export function parseDateUTC(dateStr) {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Format a Date as "YYYY-MM-DD" in UTC.
+ * @param {Date} d
+ * @returns {string}
+ */
+export function formatDateUTC(d) {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Parse a "HH:MM" time string into { hours, minutes }.
+ * @param {string} timeStr
+ * @returns {{ hours: number, minutes: number }}
+ */
+export function parseTime(timeStr) {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  return { hours, minutes };
+}
+
+/**
+ * Validate a "HH:MM" time string.
+ * @param {string} timeStr
+ * @returns {boolean}
+ */
+export function isValidTime(timeStr) {
+  if (!/^\d{2}:\d{2}$/.test(timeStr)) return false;
+  const { hours, minutes } = parseTime(timeStr);
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
+}
+
+/**
+ * Validate a "YYYY-MM-DD" date string.
+ * @param {string} dateStr
+ * @returns {boolean}
+ */
+export function isValidDate(dateStr) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
+  const d = parseDateUTC(dateStr);
+  if (Number.isNaN(d.getTime())) return false;
+  return formatDateUTC(d) === dateStr;
+}
+
+/**
+ * Given a "YYYY-MM-DD" date and "HH:MM" time (both UTC), return a Unix timestamp (seconds).
+ * @param {string} dateStr
+ * @param {string} timeStr
+ * @returns {number}
+ */
+export function toUnixTimestamp(dateStr, timeStr) {
+  const { hours, minutes } = parseTime(timeStr);
+  const d = parseDateUTC(dateStr);
+  d.setUTCHours(hours, minutes, 0, 0);
+  return Math.floor(d.getTime() / 1000);
+}
+
+/**
+ * Return a Discord-localised timestamp string using discord.js time().
+ * Default style 'f' = "DD Month YYYY HH:MM".
+ * @param {string} dateStr
+ * @param {string} timeStr
+ * @param {string} [style='f']
+ * @returns {string}
+ */
+export function discordTimestamp(dateStr, timeStr, style = 'f') {
+  return time(toUnixTimestamp(dateStr, timeStr), style);
+}
+
+/**
+ * Human-readable "Day HH:MM–HH:MM UTC" label for a schedule slot.
+ * @param {{ dayOfWeek: number, startTime: string, endTime: string }} slot
+ * @returns {string}
+ */
+export function formatSlot(slot) {
+  return `${DAY_NAMES[slot.dayOfWeek]} ${slot.startTime}–${slot.endTime} UTC`;
+}
+
+// ─── Occurrence generation ────────────────────────────────────────────────────
+
+/**
+ * An occurrence represents a single scheduled live-event session.
+ * @typedef {{ date: string, startTime: string, endTime: string }} Occurrence
+ */
+
+/**
+ * Generate all occurrences for a LiveEventSchedule within the bounds of
+ * [fromDate, toDate] (both inclusive, as Date objects at UTC midnight).
+ *
+ * Handles:
+ * - One-time events → at most one occurrence
+ * - Recurring events → one occurrence per (week × slot) combination
+ * - Skipped occurrences are excluded
+ * - Rescheduled occurrences: original slot is replaced by the replacement
+ *
+ * @param {object} schedule  — Mongoose LiveEventSchedule document (or plain object)
+ * @param {Date}   fromDate  — lower bound (UTC midnight)
+ * @param {Date}   toDate    — upper bound (UTC midnight, inclusive end-of-day)
+ * @returns {Occurrence[]}   — sorted ascending by date then startTime
+ */
+export function generateOccurrences(schedule, fromDate, toDate) {
+  /** @type {Occurrence[]} */
+  const occurrences = [];
+
+  // ── One-time event ────────────────────────────────────────────────────────
+  if (schedule.scheduleType === 'one-time') {
+    const { oneTimeDate, oneTimeStartTime, oneTimeEndTime } = schedule;
+    if (!oneTimeDate || !oneTimeStartTime || !oneTimeEndTime) return [];
+
+    const d = parseDateUTC(oneTimeDate);
+    if (d >= fromDate && d <= toDate) {
+      occurrences.push({
+        date: oneTimeDate,
+        startTime: oneTimeStartTime,
+        endTime: oneTimeEndTime,
+      });
+    }
+    return applyExceptions(occurrences, schedule, fromDate, toDate);
+  }
+
+  // ── Recurring event ───────────────────────────────────────────────────────
+  if (!schedule.recurrenceStartDate || !schedule.recurrenceEndDate) return [];
+  if (!schedule.slots || schedule.slots.length === 0) return [];
+
+  const recStart = parseDateUTC(schedule.recurrenceStartDate);
+  const recEnd = parseDateUTC(schedule.recurrenceEndDate);
+
+  // Clamp the window to the recurrence period
+  const windowStart = fromDate > recStart ? fromDate : recStart;
+  const windowEnd = toDate < recEnd ? toDate : recEnd;
+
+  if (windowStart > windowEnd) return [];
+
+  // Walk day-by-day through the window
+  const cursor = new Date(windowStart);
+  while (cursor <= windowEnd) {
+    const dow = cursor.getUTCDay();
+    const dateStr = formatDateUTC(cursor);
+
+    for (const slot of schedule.slots) {
+      if (slot.dayOfWeek === dow) {
+        occurrences.push({
+          date: dateStr,
+          startTime: slot.startTime,
+          endTime: slot.endTime,
+        });
+      }
+    }
+
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+
+  return applyExceptions(occurrences, schedule, fromDate, toDate);
+}
+
+/**
+ * Remove skipped occurrences and substitute rescheduled ones.
+ * @param {Occurrence[]} occurrences
+ * @param {object} schedule
+ * @param {Date} fromDate
+ * @param {Date} toDate
+ * @returns {Occurrence[]}
+ */
+function applyExceptions(occurrences, schedule, fromDate, toDate) {
+  const skipped = new Set(
+    (schedule.skippedOccurrences ?? []).map((s) => `${s.date}|${s.startTime}`),
+  );
+
+  // Map of originalKey → rescheduled record
+  const rescheduled = new Map(
+    (schedule.rescheduledOccurrences ?? []).map((r) => [
+      `${r.originalDate}|${r.originalStartTime}`,
+      r,
+    ]),
+  );
+
+  const result = [];
+  const originalKeys = new Set(occurrences.map((occ) => `${occ.date}|${occ.startTime}`));
+
+  for (const occ of occurrences) {
+    const key = `${occ.date}|${occ.startTime}`;
+
+    if (skipped.has(key)) continue;
+
+    if (rescheduled.has(key)) {
+      const r = rescheduled.get(key);
+      result.push({
+        date: r.newDate,
+        startTime: r.newStartTime,
+        endTime: r.newEndTime,
+        rescheduled: true,
+        originalDate: r.originalDate,
+        originalStartTime: r.originalStartTime,
+      });
+    } else {
+      result.push(occ);
+    }
+  }
+
+  // Include a replacement whose original date is outside the query window.
+  // This is needed when a future occurrence is moved into today.
+  for (const replacement of rescheduled.values()) {
+    const originalKey = `${replacement.originalDate}|${replacement.originalStartTime}`;
+    const replacementDate = parseDateUTC(replacement.newDate);
+    if (
+      !originalKeys.has(originalKey) &&
+      !skipped.has(originalKey) &&
+      isScheduledOccurrence(schedule, replacement.originalDate, replacement.originalStartTime) &&
+      replacementDate >= fromDate &&
+      replacementDate <= toDate
+    ) {
+      result.push({
+        date: replacement.newDate,
+        startTime: replacement.newStartTime,
+        endTime: replacement.newEndTime,
+        rescheduled: true,
+        originalDate: replacement.originalDate,
+        originalStartTime: replacement.originalStartTime,
+      });
+    }
+  }
+
+  const inWindow = result.filter((occ) => {
+    const occurrenceDate = parseDateUTC(occ.date);
+    return occurrenceDate >= fromDate && occurrenceDate <= toDate;
+  });
+
+  // Sort by date then startTime
+  inWindow.sort((a, b) => {
+    if (a.date !== b.date) return a.date < b.date ? -1 : 1;
+    return a.startTime < b.startTime ? -1 : 1;
+  });
+
+  return inWindow;
+}
+
+// ─── Status computation ───────────────────────────────────────────────────────
+
+/**
+ * Compute the live-event status based on upcoming / current occurrences.
+ *
+ * Returns:
+ *   'live'     — current time falls within an occurrence window
+ *   'upcoming' — at least one future occurrence exists
+ *   'ended'    — no remaining occurrences
+ *
+ * @param {object} schedule  — LiveEventSchedule document
+ * @param {Date}   [now]     — defaults to new Date()
+ * @returns {'live' | 'upcoming' | 'ended'}
+ */
+export function computeLiveEventStatus(schedule, now = new Date()) {
+  const todayStr = formatDateUTC(now);
+  const todayDate = parseDateUTC(todayStr);
+
+  // Check if we are currently inside any occurrence window
+  const todayOccurrences = generateOccurrences(schedule, todayDate, todayDate);
+  for (const occ of todayOccurrences) {
+    const startTs = toUnixTimestamp(occ.date, occ.startTime) * 1000;
+    const endTs = toUnixTimestamp(occ.date, occ.endTime) * 1000;
+    if (now.getTime() >= startTs && now.getTime() < endTs) {
+      return 'live';
+    }
+  }
+
+  // Check for any future occurrence (rest of today or beyond)
+  const farFuture = new Date(Date.UTC(9999, 11, 31));
+  const future = generateOccurrences(schedule, todayDate, farFuture);
+  // Filter strictly in the future (start time hasn't passed)
+  const hasUpcoming = future.some(
+    (occ) => toUnixTimestamp(occ.date, occ.startTime) * 1000 > now.getTime(),
+  );
+
+  return hasUpcoming ? 'upcoming' : 'ended';
+}
+
+/**
+ * Find the next occurrence after `now`.
+ * @param {object} schedule
+ * @param {Date}   [now]
+ * @returns {Occurrence | null}
+ */
+export function getNextOccurrence(schedule, now = new Date()) {
+  const todayStr = formatDateUTC(now);
+  const todayDate = parseDateUTC(todayStr);
+  const farFuture = new Date(Date.UTC(9999, 11, 31));
+
+  const all = generateOccurrences(schedule, todayDate, farFuture);
+  const nowMs = now.getTime();
+
+  return all.find((occ) => toUnixTimestamp(occ.date, occ.startTime) * 1000 > nowMs) ?? null;
+}
+
+/**
+ * Find the current occurrence (where now falls within start–end).
+ * @param {object} schedule
+ * @param {Date}   [now]
+ * @returns {Occurrence | null}
+ */
+export function getCurrentOccurrence(schedule, now = new Date()) {
+  const todayStr = formatDateUTC(now);
+  const todayDate = parseDateUTC(todayStr);
+
+  const todayOccs = generateOccurrences(schedule, todayDate, todayDate);
+  const nowMs = now.getTime();
+
+  return (
+    todayOccs.find((occ) => {
+      const startMs = toUnixTimestamp(occ.date, occ.startTime) * 1000;
+      const endMs = toUnixTimestamp(occ.date, occ.endTime) * 1000;
+      return nowMs >= startMs && nowMs < endMs;
+    }) ?? null
+  );
+}
+
+// ─── Occurrence validation helpers ───────────────────────────────────────────
+
+/**
+ * Check whether a given date+startTime corresponds to a valid scheduled
+ * occurrence for this schedule (before exception processing).
+ *
+ * Used to validate skip / reschedule targets.
+ *
+ * @param {object} schedule
+ * @param {string} dateStr      "YYYY-MM-DD"
+ * @param {string} startTime    "HH:MM"
+ * @returns {boolean}
+ */
+export function isScheduledOccurrence(schedule, dateStr, startTime) {
+  const d = parseDateUTC(dateStr);
+
+  if (schedule.scheduleType === 'one-time') {
+    return schedule.oneTimeDate === dateStr && schedule.oneTimeStartTime === startTime;
+  }
+
+  if (!schedule.recurrenceStartDate || !schedule.recurrenceEndDate) return false;
+
+  const recStart = parseDateUTC(schedule.recurrenceStartDate);
+  const recEnd = parseDateUTC(schedule.recurrenceEndDate);
+  if (d < recStart || d > recEnd) return false;
+
+  const dow = d.getUTCDay();
+  return (schedule.slots ?? []).some(
+    (slot) => slot.dayOfWeek === dow && slot.startTime === startTime,
+  );
+}
+
+/**
+ * Check whether an occurrence is currently skipped.
+ * @param {object} schedule
+ * @param {string} dateStr
+ * @param {string} startTime
+ * @returns {boolean}
+ */
+export function isSkipped(schedule, dateStr, startTime) {
+  return (schedule.skippedOccurrences ?? []).some(
+    (s) => s.date === dateStr && s.startTime === startTime,
+  );
+}
+
+/**
+ * Check whether an occurrence is currently rescheduled.
+ * @param {object} schedule
+ * @param {string} dateStr
+ * @param {string} startTime
+ * @returns {boolean}
+ */
+export function isRescheduled(schedule, dateStr, startTime) {
+  return (schedule.rescheduledOccurrences ?? []).some(
+    (r) => r.originalDate === dateStr && r.originalStartTime === startTime,
+  );
+}
+
+// ─── Calendar helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Return all occurrences that fall on a specific calendar date (UTC).
+ * Used by the event calendar to list live-event sessions per day.
+ *
+ * @param {object} schedule
+ * @param {string} dateStr  "YYYY-MM-DD"
+ * @returns {Occurrence[]}
+ */
+export function getOccurrencesOnDate(schedule, dateStr) {
+  const d = parseDateUTC(dateStr);
+  return generateOccurrences(schedule, d, d);
+}
+
+/**
+ * Return all occurrences between two dates (inclusive), both as "YYYY-MM-DD" strings.
+ * @param {object} schedule
+ * @param {string} fromDateStr
+ * @param {string} toDateStr
+ * @returns {Occurrence[]}
+ */
+export function getOccurrencesBetween(schedule, fromDateStr, toDateStr) {
+  return generateOccurrences(schedule, parseDateUTC(fromDateStr), parseDateUTC(toDateStr));
+}
+
+// ─── Parse helpers for command input ─────────────────────────────────────────
+
+/**
+ * Parse a day-of-week string (name or number) to 0–6.
+ * Accepts: "monday", "mon", "1", 1, etc.
+ * Returns null if invalid.
+ * @param {string|number} input
+ * @returns {number|null}
+ */
+export function parseDayOfWeek(input) {
+  const map = {
+    sunday: 0,
+    sun: 0,
+    monday: 1,
+    mon: 1,
+    tuesday: 2,
+    tue: 2,
+    wednesday: 3,
+    wed: 3,
+    thursday: 4,
+    thu: 4,
+    friday: 5,
+    fri: 5,
+    saturday: 6,
+    sat: 6,
+  };
+
+  if (typeof input === 'number') {
+    return input >= 0 && input <= 6 ? input : null;
+  }
+
+  const key = String(input).toLowerCase().trim();
+  if (key in map) return map[key];
+
+  const n = parseInt(key, 10);
+  if (!Number.isNaN(n) && n >= 0 && n <= 6) return n;
+
+  return null;
+}
+
+/**
+ * Build a human-readable schedule summary string for use in embeds.
+ * @param {object} schedule  — LiveEventSchedule document
+ * @returns {string}
+ */
+export function formatScheduleSummary(schedule) {
+  if (schedule.scheduleType === 'one-time') {
+    const ts = discordTimestamp(schedule.oneTimeDate, schedule.oneTimeStartTime, 'F');
+    const endTs = discordTimestamp(schedule.oneTimeDate, schedule.oneTimeEndTime, 't');
+    return `One-time · ${ts} – ${endTs}`;
+  }
+
+  const slots = (schedule.slots ?? [])
+    .map((s) => `${DAY_NAMES[s.dayOfWeek]} ${s.startTime}–${s.endTime} UTC`)
+    .join('\n');
+
+  const recStart = discordTimestamp(schedule.recurrenceStartDate, '00:00', 'D');
+  const recEnd = discordTimestamp(schedule.recurrenceEndDate, '00:00', 'D');
+
+  return `Recurring · ${recStart} → ${recEnd}\n${slots}`;
+}
+
+// ─── Schedule input parsers (shared by create and edit) ───────────────────────
+
+/**
+ * Parse one-time date + time slot from modal input.
+ * @param {string} datesRaw   "YYYY-MM-DD"
+ * @param {string} slotsRaw   "HH:MM-HH:MM"
+ * @returns {{ date: string, startTime: string, endTime: string } | { error: string }}
+ */
+export function parseOneTimeScheduleInput(datesRaw, slotsRaw) {
+  const date = datesRaw.trim();
+  if (!isValidDate(date)) {
+    return { error: 'Invalid date. Use format `YYYY-MM-DD` (e.g. `2026-08-28`).' };
+  }
+
+  const slotMatch = slotsRaw.trim().match(/^(\d{2}:\d{2})[–-](\d{2}:\d{2})$/);
+  if (!slotMatch) {
+    return { error: 'Invalid time slot. Use format `HH:MM-HH:MM` (e.g. `18:00-19:00`).' };
+  }
+
+  const [, startTime, endTime] = slotMatch;
+  if (!isValidTime(startTime)) return { error: `Invalid start time: \`${startTime}\`.` };
+  if (!isValidTime(endTime)) return { error: `Invalid end time: \`${endTime}\`.` };
+  if (startTime >= endTime) return { error: 'Start time must be before end time.' };
+
+  return { date, startTime, endTime };
+}
+
+/**
+ * Parse recurring date range + time slots from modal input.
+ * @param {string} datesRaw   "YYYY-MM-DD to YYYY-MM-DD"
+ * @param {string} slotsRaw   newline-separated "DayName HH:MM-HH:MM"
+ * @returns {{ recurrenceStartDate: string, recurrenceEndDate: string,
+ *   slots: object[] } | { error: string }}
+ */
+export function parseRecurringScheduleInput(datesRaw, slotsRaw) {
+  const dateMatch = datesRaw
+    .trim()
+    .match(/^(\d{4}-\d{2}-\d{2})\s+(?:to|[-–])\s+(\d{4}-\d{2}-\d{2})$/i);
+  if (!dateMatch) {
+    return {
+      error:
+        'Invalid recurrence range. Use `YYYY-MM-DD to YYYY-MM-DD` (e.g. `2026-08-01 to 2026-12-31`).',
+    };
+  }
+
+  const [, recurrenceStartDate, recurrenceEndDate] = dateMatch;
+
+  if (!isValidDate(recurrenceStartDate)) {
+    return { error: `Invalid recurrence start date: \`${recurrenceStartDate}\`.` };
+  }
+  if (!isValidDate(recurrenceEndDate)) {
+    return { error: `Invalid recurrence end date: \`${recurrenceEndDate}\`.` };
+  }
+  if (recurrenceEndDate <= recurrenceStartDate) {
+    return { error: 'Recurrence end date must be after recurrence start date.' };
+  }
+
+  const lines = slotsRaw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return { error: 'Recurring events must have at least one schedule slot.' };
+  }
+
+  const slots = [];
+  for (const line of lines) {
+    const match = line.match(/^(\S+)\s+(\d{2}:\d{2})[–-](\d{2}:\d{2})$/);
+    if (!match) {
+      return {
+        error:
+          `Invalid slot format: \`${line}\`. Use \`DayName HH:MM-HH:MM\` ` +
+          '(e.g. `Tuesday 18:00-19:00`).',
+      };
+    }
+
+    const [, dayStr, startTime, endTime] = match;
+    const dayOfWeek = parseDayOfWeek(dayStr);
+    if (dayOfWeek === null) {
+      return {
+        error: `Unrecognised day: \`${dayStr}\`. Use a day name like \`Tuesday\` or \`Sat\`.`,
+      };
+    }
+    if (!isValidTime(startTime)) return { error: `Invalid start time: \`${startTime}\`.` };
+    if (!isValidTime(endTime)) return { error: `Invalid end time: \`${endTime}\`.` };
+    if (startTime >= endTime) {
+      return { error: `Start time must be before end time for slot: \`${line}\`.` };
+    }
+
+    slots.push({ dayOfWeek, startTime, endTime });
+  }
+
+  return { recurrenceStartDate, recurrenceEndDate, slots };
+}

--- a/src/service/utils/permissions.js
+++ b/src/service/utils/permissions.js
@@ -1,0 +1,3 @@
+export function hasManageEventsPermission(interaction) {
+  return Boolean(interaction.member?.permissions?.has('ManageEvents'));
+}


### PR DESCRIPTION
Closes #40 

## Summary

Adds dedicated live and recurring event management through `/live-event`.

## Live Event Features

- Create one-time and recurring live events
- Support multiple weekly schedule slots
- Store hosts, locations, and event post links
- Display live events in `/calendar` and the persistent calendar channel
- Use Discord-localized timestamps
- Skip and restore individual occurrences or date ranges
- Reschedule individual occurrences without changing the recurring schedule
- Display live-event status, schedule, next occurrence, and exceptions
- Refresh the persistent calendar after live-event changes
- Remove obsolete `/event live` implementation

## Event Management Review Fixes

- Fixed `/event remove` failure caused by an undefined event ID
- Added `/event edit` validation for paired point options
- Escaped special characters in event-name lookups
- Changed autocomplete selections to use stable event IDs internally
- Added autocomplete query timeouts
- Added service-level Manage Events permission checks
- Replaced participant point/submission read-modify-write operations with atomic MongoDB `$inc` updates
- Added duplicate-key retry handling for participant upserts
- Fixed lint issues across `src/`

## Validation

- `npx eslint src`
- JavaScript syntax checks across `src/`
- Slash-command serialization checks
